### PR TITLE
[codex] Refactor virtual best baseline evaluation

### DIFF
--- a/src/experiments.py
+++ b/src/experiments.py
@@ -1032,110 +1032,54 @@ class VirtualBestBaseline:
         CIupper = names.param2filename(
             {"Key": self.parent_params.response_key, "ConfInt": "upper"}, ""
         )
-        eval_df = self.rec_params.copy()
-        eval_df.rename(
-            columns={
-                base: "response",
-                CIlower: "response_lower",
-                CIupper: "response_upper",
-            },
-            inplace=True,
-        )
-
-        eval_df = eval_df.loc[
-            :, ["resource", "response", "response_lower", "response_upper"]
-        ]
-
-        def StatsSingle(df_single: pd.DataFrame, stat_params: stats.StatsParameters):
-            """
-            Function for computing the stat (such as mean) and confidence intervals of the response
-
-            Parameters
-            ----------
-            df_single : pd.DataFrame
-                Dataframe of a single resource level
-            stat_params : stats.StatsParameters
-                Only one stats_measure will be used.
-
-            Returns
-            -------
-            pd.Dataframe
-            """
-            df_dict = {}
-            sm = stat_params.stats_measures[0]  # Ignore the rest if they exist
-            base, CIlower, CIupper = sm.ConfInts(
-                df_single["response"],
-                df_single["response_lower"],
-                df_single["response_upper"],
-            )
-
-            df_dict["response"] = [base]
-            df_dict["response_lower"] = [CIlower]
-            df_dict["response_upper"] = [CIupper]
-            df_dict["count"] = len(df_single["response"])
-
-            df_stats_single = pd.DataFrame.from_dict(df_dict)
-            return df_stats_single
-
-        def applyBounds(df: pd.DataFrame, stat_params: stats.StatsParameters):
-            """
-            Trim the response values obtained from statsSingle to be between 0 and 1
-
-            Parameters
-            ----------
-            df : pd.DataFrame
-                Dataframe of a single resource level
-            stat_params : stats.StatsParameters
-                Only one stats_measure will be used.
-            """
-            df_copy = df.loc[:, ("response_lower")].copy()
-            df_copy.clip(lower=0.0, inplace=True)
-            df.loc[:, ("response_lower")] = df_copy
-
-            df_copy = df.loc[:, ("response_upper")].copy()
-            df_copy.clip(upper=1.0, inplace=True)
-            df.loc[:, ("response_upper")] = df_copy
-            return
-
-        def Stats(
-            df: pd.DataFrame, stats_params: stats.StatsParameters, group_on=["resource"]
-        ):
-            """
-            Compute a stat(eg. mean) of the response along with CIs for it, for each value of resource for the virtual best
-
-            Parameters
-            ----------
-            df : pd.DataFrame
-                Dataframe of a single resource level with columns 'resource', 'response', 'response_lower' and 'response_upper'
-            stats_params : stats.StatsParameters
-                Only one statsMeasure will be used.
-            group_on : list[str]
-                Confidence interval propagation will be done for all rows of dataframe having the same values for groupon
-            
-            Returns
-            -------
-            pd.DataFrame
-                Dataframe with columns 'resource', 'response', 'response_lower' and 'response_upper'
-            """
-
-            def dfSS(df):
-                return StatsSingle(df, stats_params)
-
-            df_stats = df.groupby(group_on).progress_apply(dfSS, include_groups=False).reset_index()
-            df_stats.drop("level_{}".format(len(group_on)), axis=1, inplace=True)
-            applyBounds(df_stats, stats_params)
-
-            return df_stats
+        eval_df = self.rec_params.loc[:, ["resource", base, CIlower, CIupper]].copy()
 
         if median:
             stParams = stats.StatsParameters(
-                metrics=["response"], stats_measures=[stats.Median()]
+                metrics=[self.parent_params.response_key], stats_measures=[stats.Median()]
             )
-            eval_df = Stats(eval_df, stParams, ["resource"])
         else:
             stParams = stats.StatsParameters(
-                metrics=["response"], stats_measures=[stats.Mean()]
+                metrics=[self.parent_params.response_key], stats_measures=[stats.Mean()]
             )
-            eval_df = Stats(eval_df, stParams, ["resource"])
+
+        stat_measure = stParams.stats_measures[0]
+        eval_df = stats.Stats(
+            eval_df,
+            stParams,
+            ["resource"],
+            drop_singletons=False,
+        )
+
+        metric_base = names.param2filename(
+            {"Key": self.parent_params.response_key, "Metric": stat_measure.name}, ""
+        )
+        lower_name = names.param2filename(
+            {
+                "Key": self.parent_params.response_key,
+                "Metric": stat_measure.name,
+                "ConfInt": "lower",
+            },
+            "",
+        )
+        upper_name = names.param2filename(
+            {
+                "Key": self.parent_params.response_key,
+                "Metric": stat_measure.name,
+                "ConfInt": "upper",
+            },
+            "",
+        )
+        eval_df.rename(
+            columns={
+                metric_base: "response",
+                lower_name: "response_lower",
+                upper_name: "response_upper",
+            },
+            inplace=True,
+        )
+        eval_df = eval_df.loc[
+            :, ["resource", "response", "response_lower", "response_upper", "count"]
+        ]
         eval_df.reset_index(inplace=True)
         return params_df, eval_df

--- a/src/stats.py
+++ b/src/stats.py
@@ -428,7 +428,11 @@ class Quantile(StatsMeasure):
             return "Type of interval not found!"
 
 
-def StatsSingle(df_single: pd.DataFrame, stat_params: StatsParameters):
+def StatsSingle(
+    df_single: pd.DataFrame,
+    stat_params: StatsParameters,
+    drop_singletons: bool = True,
+):
     """
     Compute statistics for a single column
 
@@ -438,13 +442,15 @@ def StatsSingle(df_single: pd.DataFrame, stat_params: StatsParameters):
         Dataframe with the metric to be analyzed
     stat_params: StatsParameters
         Parameters for the statistics
+    drop_singletons: bool
+        Whether to return an empty result for groups with one row
 
     Returns
     -------
     pd.DataFrame
         Dataframe with the statistics
     """
-    if len(df_single) == 1:
+    if drop_singletons and len(df_single) == 1:
         return pd.DataFrame()
     df_dict = {}
     for sm in stat_params.stats_measures:
@@ -526,7 +532,12 @@ def applyBounds(df: pd.DataFrame, stat_params: StatsParameters):
     return
 
 
-def Stats(df: pd.DataFrame, stats_params: StatsParameters, group_on):
+def Stats(
+    df: pd.DataFrame,
+    stats_params: StatsParameters,
+    group_on,
+    drop_singletons: bool = True,
+):
     """
     Compute statistics for a dataframe
 
@@ -538,6 +549,8 @@ def Stats(df: pd.DataFrame, stats_params: StatsParameters, group_on):
         Parameters for the statistics
     group_on: list
         List of columns to group on
+    drop_singletons: bool
+        Whether to omit groups with one row
 
     Returns
     -------
@@ -546,8 +559,16 @@ def Stats(df: pd.DataFrame, stats_params: StatsParameters, group_on):
     """
 
     def dfSS(df):
-        return StatsSingle(df, stats_params)
-    df_stats = df.groupby(group_on).progress_apply(dfSS, include_groups=False).reset_index()
+        return StatsSingle(df, stats_params, drop_singletons=drop_singletons)
+
+    grouped = df.groupby(group_on)
+    try:
+        df_stats = grouped.progress_apply(dfSS, include_groups=False).reset_index()
+    except AttributeError as exc:
+        if "_is_builtin_func" not in str(exc):
+            raise
+        df_stats = grouped.apply(dfSS, include_groups=False).reset_index()
+
     df_stats.drop("level_{}".format(len(group_on)), axis=1, inplace=True)
     applyBounds(df_stats, stats_params)
 

--- a/tests/test_experiments.py
+++ b/tests/test_experiments.py
@@ -21,6 +21,7 @@ SRC_PATH = os.path.abspath(os.path.join(TESTS_DIR, os.pardir, 'src'))
 sys.path.insert(0, SRC_PATH)
 
 import experiments
+import names
 import stats
 
 
@@ -47,6 +48,27 @@ def _make_experiment_params():
     )
 
 
+def _make_virtual_best_baseline(response_key="response"):
+    params = _make_experiment_params()
+    params = experiments.ExperimentParameters(
+        parameter_names=params.parameter_names,
+        instance_cols=params.instance_cols,
+        interp_results=params.interp_results,
+        checkpoint_path=params.checkpoint_path,
+        response_key=response_key,
+        response_dir=params.response_dir,
+        smooth=params.smooth,
+        stat_params=params.stat_params,
+        training_stats=params.training_stats,
+        testing_stats=params.testing_stats,
+        evaluate_without_bootstrap=params.evaluate_without_bootstrap,
+        baseline_recalibrate=params.baseline_recalibrate,
+    )
+    baseline = experiments.VirtualBestBaseline.__new__(experiments.VirtualBestBaseline)
+    baseline.parent_params = params
+    return baseline
+
+
 class TestExperimentBaseClass:
     """Tests for the Experiment base class."""
 
@@ -57,6 +79,53 @@ class TestExperimentBaseClass:
 
         with pytest.raises(NotImplementedError, match="overridden"):
             exp.evaluate()
+
+
+class TestVirtualBestBaseline:
+    """Tests for VirtualBestBaseline evaluation."""
+
+    def test_evaluate_keeps_singleton_resource_levels(self):
+        baseline = _make_virtual_best_baseline()
+        base = names.param2filename({"Key": "response"}, "")
+        lower = names.param2filename({"Key": "response", "ConfInt": "lower"}, "")
+        upper = names.param2filename({"Key": "response", "ConfInt": "upper"}, "")
+        baseline.rec_params = pd.DataFrame(
+            {
+                "resource": [1, 2, 2],
+                "param1": [0.1, 0.2, 0.4],
+                base: [0.2, 0.3, 0.7],
+                lower: [-0.8, 0.2, 0.6],
+                upper: [1.2, 0.4, 0.8],
+            }
+        )
+
+        _, eval_df = baseline.evaluate()
+        by_resource = eval_df.set_index("resource")
+
+        assert set(by_resource.index) == {1, 2}
+        assert by_resource.loc[1, "count"] == 1
+        assert by_resource.loc[1, "response"] == pytest.approx(0.2)
+        assert by_resource.loc[1, "response_lower"] == pytest.approx(-0.8)
+        assert by_resource.loc[1, "response_upper"] == pytest.approx(1.2)
+
+    def test_evaluate_uses_response_key_bounds_when_available(self):
+        baseline = _make_virtual_best_baseline(response_key="PerfRatio")
+        base = names.param2filename({"Key": "PerfRatio"}, "")
+        lower = names.param2filename({"Key": "PerfRatio", "ConfInt": "lower"}, "")
+        upper = names.param2filename({"Key": "PerfRatio", "ConfInt": "upper"}, "")
+        baseline.rec_params = pd.DataFrame(
+            {
+                "resource": [1, 1],
+                "param1": [0.1, 0.2],
+                base: [0.95, 1.05],
+                lower: [0.7, 0.9],
+                upper: [1.2, 1.3],
+            }
+        )
+
+        _, eval_df = baseline.evaluate()
+
+        assert eval_df.loc[0, "response_upper"] == pytest.approx(1.0)
 
 
 class TestStaticRecommendationExperiment:

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -32,6 +32,30 @@ def test_StatsSingle():
     }, "The DataFrame should have the correct columns"
 
 
+def test_Stats_keeps_singleton_groups_when_requested():
+    df = pd.DataFrame(
+        {
+            "Key=A": [1.0, 2.0, 4.0],
+            "ConfInt=lower_Key=A": [0.8, 1.8, 3.8],
+            "ConfInt=upper_Key=A": [1.2, 2.2, 4.2],
+            "C": ["x", "y", "y"],
+        }
+    )
+    stats_params = StatsParameters(metrics=["A"], stats_measures=[Mean()])
+
+    default_result = Stats(df, stats_params, ["C"])
+    assert set(default_result["C"]) == {"y"}
+
+    result = Stats(df, stats_params, ["C"], drop_singletons=False)
+    result = result.set_index("C")
+
+    assert set(result.index) == {"x", "y"}
+    assert result.loc["x", "count"] == 1
+    assert result.loc["x", "Key=A_Metric=mean"] == pytest.approx(1.0)
+    assert result.loc["x", "ConfInt=lower_Key=A_Metric=mean"] == pytest.approx(0.8)
+    assert result.loc["x", "ConfInt=upper_Key=A_Metric=mean"] == pytest.approx(1.2)
+
+
 def test_applyBounds():
     df = pd.DataFrame(
         {


### PR DESCRIPTION
## Summary
- reuse shared stats.Stats utilities in VirtualBestBaseline.evaluate
- preserve singleton resource levels by adding an opt-in drop_singletons=False path
- apply response-key-specific bounds when virtual-best outputs are normalized to generic response columns
- fall back from tqdm progress_apply to groupby.apply for pandas/tqdm compatibility

## Testing
- ~/.local/bin/uv run --with-requirements requirements.txt --with-requirements requirements-dev.txt python -m pytest tests/test_stats.py tests/test_experiments.py
- ~/.local/bin/uv run --with-requirements requirements.txt --with-requirements requirements-dev.txt python run_tests.py unit
- ~/.local/bin/uv run --with-requirements requirements.txt --with-requirements requirements-dev.txt python run_tests.py integration

Supersedes bernalde/stochastic-benchmark#26.