### PR TITLE
[codex] Refactor plotting to load CSV data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -161,3 +161,10 @@ examples/**/checkpoints/*.pkl
 examples/**/checkpoints/**/*.pkl
 examples/**/*.pkl
 !examples/**/*demo*.pkl
+
+# Generated plotting CSVs from example/tutorial runs. Existing tracked CSVs
+# remain tracked; force-add only if new example fixture CSVs are intentional.
+examples/**/checkpoints/params_plotting/
+examples/**/checkpoints/performance_plotting/
+examples/**/checkpoints/meta_params_plotting/
+examples/**/checkpoints/plotting_manifest.json

--- a/src/plotting.py
+++ b/src/plotting.py
@@ -59,6 +59,8 @@ class Plotting:
         if hasattr(checkpoints_dir, "here") and hasattr(
             checkpoints_dir.here, "checkpoints"
         ):
+            if hasattr(checkpoints_dir, "export_plot_csvs"):
+                checkpoints_dir.export_plot_csvs(monotone=monotone)
             checkpoints_dir = checkpoints_dir.here.checkpoints
 
         self.checkpoints_dir = os.fspath(checkpoints_dir)

--- a/src/plotting.py
+++ b/src/plotting.py
@@ -1,13 +1,14 @@
+import json
+import logging
+import os
+
 import df_utils
 import matplotlib.patches as mpatches
 import matplotlib.pyplot as plt
+import numpy as np
 import pandas as pd
 import seaborn as sns
-import seaborn.objects as so
 import training
-import os
-import numpy as np
-import logging
 from matplotlib.collections import LineCollection
 
 monotone = False
@@ -19,125 +20,213 @@ plt.style.use(ws_style)
 
 logger = logging.getLogger(__name__)
 
+MANIFEST_NAME = "plotting_manifest.json"
+BASELINE_STEM = "baseline"
+
+
+def _read_plot_csv(path):
+    df = pd.read_csv(path)
+    if "resource" not in df.columns and "index" in df.columns:
+        df.rename(columns={"index": "resource"}, inplace=True)
+
+    drop_cols = [
+        col
+        for col in df.columns
+        if col.startswith("Unnamed:")
+        or col == "level_0"
+        or (col == "index" and "resource" in df.columns)
+    ]
+    if drop_cols:
+        df.drop(columns=drop_cols, inplace=True)
+    return df
+
+
+def _is_preprocessed_params_stem(stem):
+    return stem.endswith("_preproc") or stem.endswith("params")
+
 
 class Plotting:
     """
-    Plotting helpers for coordinating plots
+    Plotting helpers that read exported plotting data from CSV files.
 
-    Attributes
+    Parameters
     ----------
-    parent : stochatic_benchmark
-    colors : list[str]
-        Color palette for experiments. Baseline will always be black
-    xcale : str
-        scale for shared x axis
-    xlims : tuple
-        limits for shared x axis
-
-    Methods
-    -------
-    __init__(parent)
-        Initialize plotting object
-    set_colors(cp)
-        Sets color palette and reassigns colors to experiments
-    set_xlims(xlims)
-        Sets limits for shared x
-    make_legend(ax, baseline_bool, experiment_bools)
-        Makes legend for each experiment
-    apply_shared(p, baseline_bool=True, experiment_bools=None)
-        Apply shared plot components (xscale, xlim, legends)
-    assign_colors()
-        Assigns colors to experiments
-    plot_parameters_together()
-        Plot the parameters together
-    store_baseline_params(params_df)
-        Store baseline parameters
-    store_expt_params(experiment_name, res)
-        Store experiment parameters
-    plot_parameters_separate()
-        Plot the parameters separately
-    plot_parameters_distance()
-        Plot the parameters distance to the virtual best
-    plot_performance()
-        Plot the performance
-    plot_meta_parameters()
-        Plot the meta parameters
+    checkpoints_dir : str or path-like
+        Directory containing the plotting CSV subdirectories.
     """
 
-    def __init__(self, parent):
-        self.parent = parent
-        self.colors = ["blue", "green", "red", "purple", "orange", "cyan"]
-        self.colors = sns.color_palette("tab10", len(self.parent.experiments))
-        self.assign_colors()
+    def __init__(self, checkpoints_dir):
+        if hasattr(checkpoints_dir, "here") and hasattr(
+            checkpoints_dir.here, "checkpoints"
+        ):
+            checkpoints_dir = checkpoints_dir.here.checkpoints
+
+        self.checkpoints_dir = os.fspath(checkpoints_dir)
+        self.params_dir = os.path.join(self.checkpoints_dir, "params_plotting")
+        self.perf_dir = os.path.join(self.checkpoints_dir, "performance_plotting")
+        self.meta_dir = os.path.join(self.checkpoints_dir, "meta_params_plotting")
+
+        self.manifest = self._load_manifest()
+        self.baseline_name = self.manifest.get("baseline_name", "baseline")
+        self.response_key = self.manifest.get("response_key", "response")
+        self.parameter_names = (
+            self.manifest.get("parameter_names") or self._infer_parameter_names()
+        )
+
+        self.experiment_info = {
+            exp["name"]: exp for exp in self.manifest.get("experiments", [])
+        }
+        self.experiment_names = (
+            list(self.experiment_info) or self._infer_experiment_names()
+        )
+
+        self.colors = sns.color_palette("tab10", max(len(self.experiment_names), 1))
+        self.baseline_color = "black"
+        self._assign_experiment_colors()
         self.xscale = "log"
+
+    def _load_manifest(self):
+        manifest_path = os.path.join(self.checkpoints_dir, MANIFEST_NAME)
+        if not os.path.exists(manifest_path):
+            return {}
+        try:
+            with open(manifest_path, "r", encoding="utf-8") as fh:
+                return json.load(fh)
+        except json.JSONDecodeError:
+            logger.warning("Could not parse plotting manifest at %s", manifest_path)
+            return {}
+
+    def _infer_parameter_names(self):
+        baseline_csv = self._params_path(BASELINE_STEM)
+        if not os.path.exists(baseline_csv):
+            return []
+        df = _read_plot_csv(baseline_csv)
+        return [col for col in df.columns if col != "resource"]
+
+    def _infer_experiment_names(self):
+        names = []
+        for directory in [self.params_dir, self.perf_dir]:
+            if not os.path.exists(directory):
+                continue
+            for filename in sorted(os.listdir(directory)):
+                stem, ext = os.path.splitext(filename)
+                if (
+                    ext != ".csv"
+                    or stem == BASELINE_STEM
+                    or _is_preprocessed_params_stem(stem)
+                ):
+                    continue
+                if stem not in names:
+                    names.append(stem)
+        return names
+
+    def _assign_experiment_colors(self):
+        if len(self.colors) == 0:
+            self.experiment_colors = {}
+            return
+        self.experiment_colors = {
+            name: self.colors[idx % len(self.colors)]
+            for idx, name in enumerate(self.experiment_names)
+        }
+
+    def _params_path(self, name):
+        return os.path.join(self.params_dir, f"{name}.csv")
+
+    def _performance_path(self, name):
+        return os.path.join(self.perf_dir, f"{name}.csv")
+
+    def _meta_path(self, name):
+        return os.path.join(self.meta_dir, f"{name}.csv")
+
+    def _preprocessed_params_path(self, name):
+        candidates = [
+            os.path.join(self.params_dir, f"{name}_preproc.csv"),
+            os.path.join(self.params_dir, f"{name}params.csv"),
+        ]
+        return next(
+            (path for path in candidates if os.path.exists(path)), candidates[0]
+        )
+
+    def _preprocessed_meta_path(self, name):
+        return os.path.join(self.meta_dir, f"{name}_preproc.csv")
+
+    def _experiment_has_meta(self, name):
+        info = self.experiment_info.get(name, {})
+        if "has_meta" in info:
+            return info["has_meta"]
+        return os.path.exists(self._meta_path(name))
+
+    def _meta_parameter_names(self, name, metaparams_df):
+        info = self.experiment_info.get(name, {})
+        if info.get("meta_parameter_names"):
+            return [
+                col
+                for col in info["meta_parameter_names"]
+                if col in metaparams_df.columns
+            ]
+
+        ignored = {
+            "TotalBudget",
+            "ExplorationBudget",
+            "resource",
+            "response",
+            "response_lower",
+            "response_upper",
+            "count",
+        }
+        return [
+            col
+            for col in metaparams_df.columns
+            if col not in ignored and not col.startswith("Key=")
+        ]
+
+    def _meta_resource_column(self, name, metaparams_df):
+        info = self.experiment_info.get(name, {})
+        resource_col = info.get("meta_resource", "TotalBudget")
+        if resource_col in metaparams_df.columns:
+            return resource_col
+        if "TotalBudget" in metaparams_df.columns:
+            return "TotalBudget"
+        return "resource"
 
     def set_colors(self, cp):
         """
-        Sets color palette and reassigns colors to experiments
-
-        Parameters
-        ----------
-        cp : list[str]
-            Color palette for experiments. Baseline will always be black
+        Sets color palette and reassigns colors to experiments.
         """
         self.colors = cp
-        self.assign_colors()
+        self._assign_experiment_colors()
 
     def set_xlims(self, xlims):
         """
-        Sets limits for shared x
-
-        Parameters
-        ----------
-        xlims : tuple
-            limits for shared x axis
+        Sets limits for shared x axis.
         """
         self.xlims = xlims
 
     def make_legend(self, ax, baseline_bool, experiment_bools):
         """
-        Makes legend for each experiment
-
-        Parameters
-        ----------
-        ax : matplotlib.axes
-            axes to plot on
-        baseline_bool : bool
-            whether to include baseline in legend
-        experiment_bools : list[bool]
-            whether to include each experiment in legend
+        Makes legend entries for the baseline and selected experiments.
         """
         if baseline_bool:
             color_patches = [
-                mpatches.Patch(
-                    color=self.parent.baseline.color, label=self.parent.baseline.name
-                )
+                mpatches.Patch(color=self.baseline_color, label=self.baseline_name)
             ]
         else:
             color_patches = []
 
-        color_patches = color_patches + [
-            mpatches.Patch(color=experiment.color, label=experiment.name)
-            for idx, experiment in enumerate(self.parent.experiments)
-            if experiment_bools[idx]
-        ]
-        ax.legend(handles=[cpatch for cpatch in color_patches])
+        for idx, name in enumerate(self.experiment_names):
+            if experiment_bools[idx]:
+                color_patches.append(
+                    mpatches.Patch(color=self.experiment_colors[name], label=name)
+                )
+
+        ax.legend(handles=color_patches)
 
     def apply_shared(self, p, baseline_bool=True, experiment_bools=None):
         """
-        Apply shared plot components (xscale, xlim, legends)
-
-        Parameters
-        ----------
-        p : seaborn object
-            plot to apply shared components to
-        baseline_bool : bool
-            whether to include baseline in legend
-        experiment_bools : list[bool]
-            whether to include each experiment in legend
+        Apply shared plot components such as x-scale, x-limits, and legends.
         """
         if experiment_bools is None:
-            experiment_bools = [True] * len(self.parent.experiments)
+            experiment_bools = [True] * len(self.experiment_names)
 
         if type(p) is dict:
             for k, v in p.items():
@@ -155,231 +244,125 @@ class Plotting:
 
         return fig
 
-    def assign_colors(self):
-        """
-        Assigns colors to experiments
-        """
-        self.parent.baseline.color = "black"
-        for idx, experiment in enumerate(self.parent.experiments):
-            experiment.color = self.colors[idx]
+    def _plot_baseline_parameter_trace(self, ax, params_df, eval_df, param):
+        points = np.array(
+            [params_df["resource"].values, params_df[param].values]
+        ).T.reshape(-1, 1, 2)
+        segments = np.concatenate([points[:-1], points[1:]], axis=1)
+        norm = plt.Normalize(eval_df["response"].min(), eval_df["response"].max())
+        lc = LineCollection(segments, cmap="Spectral", norm=norm)
+        lc.set_array(eval_df["response"].values)
+        lc.set_label(self.baseline_name)
+        lc.set_linewidth(8)
+        lc.set_alpha(0.75)
+        line = ax.add_collection(lc)
+        ax.plot(params_df["resource"], params_df[param], "o", ms=2, mec="k", alpha=0.25)
+        return line
 
-    def plot_parameters_together(self):
-        """Plot the parameters (Virtual Best and projection experiments)
-        Create a single figure with a subfigure corresponding to each parameter
+    def _plot_experiment_parameter_traces(self, axes):
+        for experiment_name in self.experiment_names:
+            params_path = self._params_path(experiment_name)
+            if not os.path.exists(params_path):
+                continue
 
-        Returns
-        -------
-        fig : matplotlib.figure
-            Figure handle
-        axes : dict
-            Dictionary of axis handles. The keys are the parameter names
-        """
+            params_df = _read_plot_csv(params_path)
+            preproc_path = self._preprocessed_params_path(experiment_name)
+            has_meta = self._experiment_has_meta(experiment_name)
 
-        fig, axes_list = plt.subplots(len(self.parent.parameter_names), 1)
+            for param in self.parameter_names:
+                if param not in params_df.columns:
+                    continue
 
-        # Convert axes_list to a dictionary
-        axes = dict()
-        for ind, param in enumerate(self.parent.parameter_names):
-            axes[param] = axes_list[ind]
-
-        # Get the best parameters from the Virtual Baseline
-        params_df, eval_df = self.parent.baseline.evaluate()
-        eval_df = df_utils.monotone_df(eval_df, "resource", "response", 1)
-
-        # Before plotting, store params_df to a csv file
-        self.store_baseline_params(params_df)
-
-        # plot the virtual baseline parameters
-        for param in self.parent.parameter_names:
-            points = np.array(
-                [params_df.index.values, params_df[param].values]
-            ).T.reshape(-1, 1, 2)
-            segments = np.concatenate([points[:-1], points[1:]], axis=1)
-            norm = plt.Normalize(eval_df["response"].min(), eval_df["response"].max())
-            lc = LineCollection(segments, cmap="Spectral", norm=norm)
-            # Set the values used for colormapping
-            lc.set_array(eval_df["response"])
-            lc.set_label(self.parent.baseline.name)
-            lc.set_linewidth(8)
-            lc.set_alpha(0.75)
-            line = axes[param].add_collection(lc)
-            _ = axes[param].plot(
-                params_df.index, params_df[param], "o", ms=2, mec="k", alpha=0.25
-            )
-
-        cbar = fig.colorbar(line, ax=axes_list.ravel().tolist())
-        cbar.ax.tick_params()
-        cbar.set_label(self.parent.response_key)
-
-        # Plot parameters from experiments
-        for experiment in self.parent.experiments:
-            # Choose whether to monotomize experiment parameters
-            logger.info("Plotting experiment %s", experiment)
-            if monotone:
-                res = experiment.evaluate_monotone()
-            else:
-                res = experiment.evaluate()
-            params_df = res[0]
-            eval_df = res[1]
-
-            for param in self.parent.parameter_names:
-                if not hasattr(experiment, "meta_params"):
-                    # Store experiment parameters to csv before plotting
-                    self.store_expt_params(experiment.name, res)
-                    # Plot only if experiment does not have meta_parameters
-                    _ = axes[param].plot(
+                if not has_meta:
+                    axes[param].plot(
                         params_df["resource"],
                         params_df[param],
                         "o-",
                         ms=2,
                         lw=1.5,
-                        color=experiment.color,
-                        label=experiment.name,
-                    )
-                if len(res) == 3:
-                    # Len=3 only if postprocessing was used. In that case also plot the recipe before the postprocessing was done
-                    preproc_params = res[2]
-                    axes[param].plot(
-                        preproc_params["resource"],
-                        preproc_params[param],
-                        color=experiment.color,
-                        marker="x",
-                        linestyle=":",
-                        ms=2,
-                        lw=1.5,
+                        color=self.experiment_colors[experiment_name],
+                        label=experiment_name,
                     )
 
-        # Finally, add more properties such as labels, legend, etc.
-        for param in self.parent.parameter_names:
+                if os.path.exists(preproc_path):
+                    preproc_params = _read_plot_csv(preproc_path)
+                    if param in preproc_params.columns:
+                        axes[param].plot(
+                            preproc_params["resource"],
+                            preproc_params[param],
+                            color=self.experiment_colors[experiment_name],
+                            marker="x",
+                            linestyle=":",
+                            ms=2,
+                            lw=1.5,
+                        )
+
+    def plot_parameters_together(self):
+        """Plot the parameters in one figure with a subplot per parameter."""
+        if not self.parameter_names:
+            raise ValueError("No parameter CSV data found for plotting")
+
+        fig, axes_list = plt.subplots(len(self.parameter_names), 1)
+        axes_array = np.atleast_1d(axes_list).ravel()
+        axes = {
+            param: axes_array[ind] for ind, param in enumerate(self.parameter_names)
+        }
+
+        params_df = _read_plot_csv(self._params_path(BASELINE_STEM))
+        eval_df = _read_plot_csv(self._performance_path(BASELINE_STEM))
+        eval_df = df_utils.monotone_df(eval_df, "resource", "response", 1)
+
+        line = None
+        for param in self.parameter_names:
+            line = self._plot_baseline_parameter_trace(
+                axes[param], params_df, eval_df, param
+            )
+
+        if line is not None:
+            cbar = fig.colorbar(line, ax=axes_array.tolist())
+            cbar.ax.tick_params()
+            cbar.set_label(self.response_key)
+
+        self._plot_experiment_parameter_traces(axes)
+
+        for param in self.parameter_names:
             axes[param].grid(axis="y")
             axes[param].set_ylabel(param)
             axes[param].set_xscale(self.xscale)
             axes[param].set_xlabel("Resource")
             if hasattr(self, "xlims"):
                 axes[param].set_xlim(self.xlims)
-            # axes[param].legend()
-        handles, labels = axes_list[0].get_legend_handles_labels()
-        fig.legend(handles, labels, bbox_to_anchor=[0.5, 0], loc="upper center")
-        # plt.legend()
-        # fig.tight_layout()
 
+        handles, labels = axes_array[0].get_legend_handles_labels()
+        fig.legend(handles, labels, bbox_to_anchor=[0.5, 0], loc="upper center")
         return fig, axes
 
-    def store_baseline_params(self, params_df):
-        """
-        Store dataframe which has the data that is plotted for baseline parameters, to a csv file
-        
-        Parameters:
-            params_df (pd.DataFrame): Dataframe with parameters that are plotted for baseline
-        """
-        save_loc = os.path.join(self.parent.here.checkpoints, "params_plotting")
-        if not os.path.exists(save_loc):
-            os.makedirs(save_loc)
-        save_file = os.path.join(save_loc, "baseline.csv")
-        params_df.to_csv(save_file)
-
-    def store_expt_params(self, experiment_name, res):
-        """
-        Store data that will be used for plotting parameters from experiment
-        Parameters:
-            experiment_name (str): Name of the experiment (i.e. experiment.name)
-            res (list): list with 2 or 3 items. res[0] is params_df (i.e. final params from expt), while res[2] (if it exists) contains parameters before post-processing.
-        """
-        save_loc = os.path.join(self.parent.here.checkpoints, "params_plotting")
-        save_file = os.path.join(save_loc, experiment_name + ".csv")
-        params_df = res[0]
-        params_df.to_csv(save_file)
-        if len(res) == 3:
-            # Len=3 only if postprocessing was used.
-            preproc_params = res[2]
-            save_file = os.path.join(save_loc, experiment_name + "params.csv")
-            preproc_params.to_csv(save_file)
-
     def plot_parameters_separate(self):
-        """Plot the parameters (Virtual Best and projection experiments)
-        Create a separate figure for each parameter
+        """Plot each parameter in a separate figure."""
+        if not self.parameter_names:
+            raise ValueError("No parameter CSV data found for plotting")
 
-        Returns:
-            figs: Dictionary of figure handles. The keys are the parameter names
-            axes: Dictionary of axis handles. The keys are the parameter names
-        """
-        # For each resource value, obtain the best parameter value from VirtualBestBaseline
+        figs = {}
+        axes = {}
 
-        figs = dict()
-        axes = dict()
-
-        for param in self.parent.parameter_names:
-            # Create one figure for each parameter
+        for param in self.parameter_names:
             figs[param], axes[param] = plt.subplots(1, 1)
 
-        # Get the best parameters from the Virtual Baseline
-        params_df, eval_df = self.parent.baseline.evaluate()
+        params_df = _read_plot_csv(self._params_path(BASELINE_STEM))
+        eval_df = _read_plot_csv(self._performance_path(BASELINE_STEM))
         eval_df = df_utils.monotone_df(eval_df, "resource", "response", 1)
 
-        # Before plotting, store params_df to a csv file
-        self.store_baseline_params(params_df)
-
-        # plot the virtual baseline parameters
-        for param in self.parent.parameter_names:
-            points = np.array(
-                [params_df.index.values, params_df[param].values]
-            ).T.reshape(-1, 1, 2)
-            segments = np.concatenate([points[:-1], points[1:]], axis=1)
-            norm = plt.Normalize(eval_df["response"].min(), eval_df["response"].max())
-            lc = LineCollection(segments, cmap="Spectral", norm=norm)
-            # Set the values used for colormapping
-            lc.set_array(eval_df["response"])
-            lc.set_label(self.parent.baseline.name)
-            lc.set_linewidth(8)
-            lc.set_alpha(0.75)
-            line = axes[param].add_collection(lc)
+        for param in self.parameter_names:
+            line = self._plot_baseline_parameter_trace(
+                axes[param], params_df, eval_df, param
+            )
             cbar = figs[param].colorbar(line, ax=axes[param])
             cbar.ax.tick_params()
-            cbar.set_label(self.parent.response_key)
+            cbar.set_label(self.response_key)
 
-            _ = axes[param].plot(
-                params_df.index, params_df[param], "o", ms=2, mec="k", alpha=0.25
-            )
+        self._plot_experiment_parameter_traces(axes)
 
-        # Plot parameters from experiments
-        for experiment in self.parent.experiments:
-            # Choose whether to monotomize experiment parameters
-            if monotone:
-                res = experiment.evaluate_monotone()
-            else:
-                res = experiment.evaluate()
-            params_df = res[0]
-            eval_df = res[1]
-
-            for param in self.parent.parameter_names:
-                if not hasattr(experiment, "meta_params"):
-                    # Store experiment parameters to csv file before plotting
-                    self.store_expt_params(experiment.name, res)
-                    # Plot only if experiment does not have meta_parameters
-                    _ = axes[param].plot(
-                        params_df["resource"],
-                        params_df[param],
-                        "o-",
-                        ms=2,
-                        lw=1.5,
-                        color=experiment.color,
-                        label=experiment.name,
-                    )
-                if len(res) == 3:
-                    # Len=3 only if postprocessing was used. In that case also plot the recipe before the postprocessing was done
-                    preproc_params = res[2]
-                    axes[param].plot(
-                        preproc_params["resource"],
-                        preproc_params[param],
-                        color=experiment.color,
-                        marker="x",
-                        linestyle=":",
-                        ms=2,
-                        lw=1.5,
-                    )
-
-        # Finally, add more properties such as labels, legend, etc.
-        for param in self.parent.parameter_names:
+        for param in self.parameter_names:
             axes[param].grid(axis="y")
             axes[param].set_ylabel(param)
             axes[param].set_xscale(self.xscale)
@@ -393,28 +376,29 @@ class Plotting:
 
     def plot_parameters_distance(self):
         """
-        Plots the scaled distance between the recommended parameters and virtual best
+        Plots the scaled distance between recommended parameters and virtual best.
         """
-        recipes, _ = self.parent.baseline.evaluate()
+        recipes = _read_plot_csv(self._params_path(BASELINE_STEM))
 
         all_params_list = []
-        count = 0
-        for experiment in self.parent.experiments:
-            if monotone:
-                params_df = experiment.evaluate_monotone()[0]
-            else:
-                params_df = experiment.evaluate()[0]
+        for count, experiment_name in enumerate(self.experiment_names):
+            params_path = self._params_path(experiment_name)
+            if not os.path.exists(params_path):
+                continue
+            params_df = _read_plot_csv(params_path)
             params_df["exp_idx"] = count
             all_params_list.append(params_df)
-            count += 1
+
+        if not all_params_list:
+            raise ValueError("No experiment parameter CSV data found for plotting")
 
         all_params = pd.concat(all_params_list, ignore_index=True)
         dist_params_list = []
 
-        for _, recipe in recipes.reset_index().iterrows():
+        for _, recipe in recipes.iterrows():
             res_df = all_params[all_params["resource"] == recipe["resource"]]
             temp_df_eval = training.scaled_distance(
-                res_df, recipe, self.parent.parameter_names
+                res_df, recipe, self.parameter_names
             )
             temp_df_eval.loc[:, "resource"] = recipe["resource"]
             dist_params_list.append(temp_df_eval)
@@ -423,26 +407,26 @@ class Plotting:
         fig, axs = plt.subplots(1, 1)
         axs.plot(all_params["resource"], all_params["distance_scaled"])
 
-        for idx, experiment in enumerate(self.parent.experiments):
-            metaflag = hasattr(experiment, "meta_params")
+        for idx, experiment_name in enumerate(self.experiment_names):
             params_df = all_params[all_params["exp_idx"] == idx]
-            if metaflag:
-                axs.plot(
-                    params_df["resource"],
-                    params_df["distance_scaled"],
-                    marker="x",
-                    linestyle=":",
-                    color=experiment.color,
-                    label=experiment.name,
-                )
+            if len(params_df) == 0:
+                continue
+
+            if self._experiment_has_meta(experiment_name):
+                marker = "x"
+                linestyle = ":"
             else:
-                axs.plot(
-                    params_df["resource"],
-                    params_df["distance_scaled"],
-                    marker="o",
-                    color=experiment.color,
-                    label=experiment.name,
-                )
+                marker = "o"
+                linestyle = "-"
+
+            axs.plot(
+                params_df["resource"],
+                params_df["distance_scaled"],
+                marker=marker,
+                linestyle=linestyle,
+                color=self.experiment_colors[experiment_name],
+                label=experiment_name,
+            )
 
         axs.grid(axis="y")
         axs.set_ylabel("distance_scaled")
@@ -455,20 +439,9 @@ class Plotting:
 
     def plot_performance(self):
         """
-        Plots the monotonized performance for each experiment (with the baseline)
+        Plots monotonized performance for each experiment and the baseline.
         """
-        # If saved data for virtual best exists, simply load it. Otherwise, compute the curve from baseline.
-        save_loc = os.path.join(self.parent.here.checkpoints, "performance_plotting")
-        if not os.path.exists(save_loc):
-            os.makedirs(save_loc)
-        save_file = os.path.join(save_loc, "baseline.csv")
-        if os.path.exists(save_file):
-            eval_df = pd.read_csv(save_file)
-        else:
-            _, eval_df = self.parent.baseline.evaluate()
-            eval_df = df_utils.monotone_df(eval_df, "resource", "response", 1)
-            # Store eval_df to a csv file
-            eval_df.to_csv(save_file)
+        eval_df = _read_plot_csv(self._performance_path(BASELINE_STEM))
 
         fig, axs = plt.subplots(1, 1)
         if plot_vb_CI:
@@ -480,54 +453,42 @@ class Plotting:
                 color="k",
                 lw=0,
             )
-        _ = axs.plot(
+        axs.plot(
             eval_df["resource"],
             eval_df["response"],
             "o-",
             ms=5,
             lw=1,
-            color=self.parent.baseline.color,
-            label=self.parent.baseline.name,
+            color=self.baseline_color,
+            label=self.baseline_name,
         )
 
-        for experiment in self.parent.experiments:
-            try:
-                save_file = os.path.join(save_loc, experiment.name + ".csv")
-                if os.path.exists(save_file):
-                    eval_df = pd.read_csv(save_file)
-                else:
-                    if monotone and not experiment.name == "SequentialSearch_cold":
-                        res = experiment.evaluate_monotone()
-                    else:
-                        res = experiment.evaluate()
-                    eval_df = res[1]
-                    # Store eval_df to a csv file
-                    eval_df.to_csv(save_file)
-
-                # Add confidence intervals
-                axs.fill_between(
-                    eval_df["resource"],
-                    eval_df["response_lower"],
-                    eval_df["response_upper"],
-                    alpha=0.25,
-                    color=experiment.color,
-                    lw=0,
-                )  # , label="CI Mean"+legend_str) # color='b',
-                # Add mean/median line
-                _ = axs.plot(
-                    eval_df["resource"],
-                    eval_df["response"],
-                    "o-",
-                    ms=5,
-                    lw=1,
-                    color=experiment.color,
-                    label=experiment.name,
-                )
-            except:
+        for experiment_name in self.experiment_names:
+            save_file = self._performance_path(experiment_name)
+            if not os.path.exists(save_file):
                 continue
 
+            eval_df = _read_plot_csv(save_file)
+            axs.fill_between(
+                eval_df["resource"],
+                eval_df["response_lower"],
+                eval_df["response_upper"],
+                alpha=0.25,
+                color=self.experiment_colors[experiment_name],
+                lw=0,
+            )
+            axs.plot(
+                eval_df["resource"],
+                eval_df["response"],
+                "o-",
+                ms=5,
+                lw=1,
+                color=self.experiment_colors[experiment_name],
+                label=experiment_name,
+            )
+
         axs.grid(axis="y")
-        axs.set_ylabel(self.parent.response_key)
+        axs.set_ylabel(self.response_key)
         axs.set_xscale(self.xscale)
         axs.set_xlabel("Resource")
         if hasattr(self, "xlims"):
@@ -538,77 +499,58 @@ class Plotting:
 
     def plot_meta_parameters(self):
         """
-        Plots meta parameters for experiments that have them (random search and sequential search)
+        Plots meta parameters for experiments that have them.
         """
-        figs = dict()
-        axes = dict()
+        figs = {}
+        axes = {}
 
-        # Location where meta parameter csv files are saved or are to be saved
-        save_loc = os.path.join(self.parent.here.checkpoints, "meta_params_plotting")
-        if not os.path.exists(save_loc):
-            os.makedirs(save_loc)
+        for experiment_name in self.experiment_names:
+            exp_figs = {}
+            exp_axes = {}
+            save_file = self._meta_path(experiment_name)
+            if not os.path.exists(save_file):
+                figs[experiment_name] = exp_figs
+                axes[experiment_name] = exp_axes
+                continue
 
-        for idx, experiment in enumerate(self.parent.experiments):
-            exp_figs = dict()
-            exp_axes = dict()
-            if hasattr(experiment, "meta_params"):
-                # LOAD metaparameter data for this experiment
-                # Check if metaparameter csv files exist. If yes, load them into memory. Otherwise, get from the experiment, load into memory, and store to scv
-                save_file = os.path.join(save_loc, experiment.name + ".csv")
-                if os.path.exists(save_file):
-                    metaparams_df = pd.read_csv(save_file)
-                else:
-                    metaparams_df = experiment.meta_params
-                    metaparams_df.sort_values(by="TotalBudget", inplace=True)
-                    metaparams_df.to_csv(save_file)
+            metaparams_df = _read_plot_csv(save_file)
+            resource_col = self._meta_resource_column(experiment_name, metaparams_df)
 
-                metaparams_preproc_df = None
-                if hasattr(experiment, "preproc_meta_params"):
-                    save_file = os.path.join(save_loc, experiment.name + "_preproc.csv")
-                    if os.path.exists(save_file):
-                        metaparams_preproc_df = pd.read_csv(save_file)
-                    else:
-                        metaparams_preproc_df = experiment.preproc_meta_params
-                        metaparams_preproc_df.sort_values(
-                            by=experiment.resource, inplace=True
-                        )
-                        metaparams_preproc_df.to_csv(save_file)
+            preproc_file = self._preprocessed_meta_path(experiment_name)
+            metaparams_preproc_df = None
+            if os.path.exists(preproc_file):
+                metaparams_preproc_df = _read_plot_csv(preproc_file)
 
-                for param in experiment.meta_parameter_names:
-                    # Create a figure for each parameter and each experiment
-                    fig, axs = plt.subplots(1, 1)
+            for param in self._meta_parameter_names(experiment_name, metaparams_df):
+                fig, axs = plt.subplots(1, 1)
+                axs.plot(
+                    metaparams_df[resource_col],
+                    metaparams_df[param],
+                    color=self.experiment_colors[experiment_name],
+                    marker="o",
+                    label=experiment_name,
+                )
+                if (
+                    metaparams_preproc_df is not None
+                    and param in metaparams_preproc_df.columns
+                    and resource_col in metaparams_preproc_df.columns
+                ):
                     axs.plot(
-                        metaparams_df["TotalBudget"],
-                        metaparams_df[param],
-                        color=experiment.color,
-                        marker="o",
-                        label=experiment.name,
+                        metaparams_preproc_df[resource_col],
+                        metaparams_preproc_df[param],
+                        color=self.experiment_colors[experiment_name],
+                        marker="x",
+                        linestyle="--",
                     )
-                    if (
-                        metaparams_preproc_df is not None
-                    ):  # hasattr(experiment, 'preproc_meta_params'):
-                        axs.plot(
-                            metaparams_preproc_df["TotalBudget"],
-                            metaparams_preproc_df[param],
-                            color=experiment.color,
-                            marker="x",
-                            linestyle="--",
-                        )
-                    axs.grid(axis="y")
-                    axs.set_ylabel(param)
-                    axs.set_xscale(self.xscale)
-                    axs.set_xlabel("TotalBudget")  # experiment.resource)
-                    axs.legend(loc="best")
-                    fig.tight_layout()
-                    exp_figs[param] = fig
-                    exp_axes[param] = axs
-                baseline_bool = False
-                experiment_bools = [False] * len(self.parent.experiments)
-                experiment_bools[idx] = True
-                # exp_plot_dict = self.apply_shared(exp_plot_dict,
-                #                                    baseline_bool=baseline_bool,
-                #                                    experiment_bools=experiment_bools)
-                # plots_dict[experiment.name] = exp_plot_dict
-            figs[experiment.name] = exp_figs
-            axes[experiment.name] = exp_axes
+                axs.grid(axis="y")
+                axs.set_ylabel(param)
+                axs.set_xscale(self.xscale)
+                axs.set_xlabel(resource_col)
+                axs.legend(loc="best")
+                fig.tight_layout()
+                exp_figs[param] = fig
+                exp_axes[param] = axs
+
+            figs[experiment_name] = exp_figs
+            axes[experiment_name] = exp_axes
         return figs, axes

--- a/src/stochastic_benchmark.py
+++ b/src/stochastic_benchmark.py
@@ -1,5 +1,6 @@
 from collections import defaultdict
 import glob
+import json
 import numpy as np
 import os
 import pandas as pd
@@ -741,10 +742,193 @@ class stochastic_benchmark:
             Experiment object
         """
         logger.info("Running static recommendation experiment")
-        self.experiments.append(StaticRecommendationExperiment(self.get_experiment_parameters(), init_from))
+        self.experiments.append(
+            StaticRecommendationExperiment(self.get_experiment_parameters(), init_from)
+        )
 
-    def initPlotting(self):
+    @staticmethod
+    def _plotting_csv_frame(
+        df,
+        required_columns=None,
+        optional_columns=None,
+        resource_column="resource",
+    ):
+        result = df.copy()
+        if resource_column not in result.columns:
+            result = result.reset_index()
+            if resource_column not in result.columns and "index" in result.columns:
+                result.rename(columns={"index": resource_column}, inplace=True)
+
+        drop_cols = [
+            col
+            for col in result.columns
+            if col.startswith("Unnamed:")
+            or col == "level_0"
+            or (col == "index" and resource_column in result.columns)
+        ]
+        if drop_cols:
+            result.drop(columns=drop_cols, inplace=True)
+
+        required_columns = required_columns or []
+        optional_columns = optional_columns or []
+        missing = [col for col in required_columns if col not in result.columns]
+        if missing:
+            raise ValueError(
+                "Cannot export plotting CSV; missing columns: {}".format(missing)
+            )
+
+        columns = list(required_columns)
+        columns.extend(
+            col
+            for col in optional_columns
+            if col in result.columns and col not in columns
+        )
+        if columns:
+            result = result.loc[:, columns]
+        return result
+
+    def _write_plotting_csv(
+        self,
+        df,
+        path,
+        required_columns=None,
+        optional_columns=None,
+        resource_column="resource",
+    ):
+        csv_df = self._plotting_csv_frame(
+            df,
+            required_columns=required_columns,
+            optional_columns=optional_columns,
+            resource_column=resource_column,
+        )
+        csv_df.to_csv(path, index=False)
+
+    def export_plot_csvs(self, monotone=False):
+        """
+        Export the CSV files used by the plotting module.
+
+        This separates plot rendering from in-memory benchmark objects. After this
+        method runs, ``plotting.Plotting`` can recreate plots from the checkpoint
+        directory alone.
+        """
+        if not hasattr(self, "baseline"):
+            raise AttributeError("run_baseline() must be called before exporting plots")
+
+        params_dir = os.path.join(self.here.checkpoints, "params_plotting")
+        perf_dir = os.path.join(self.here.checkpoints, "performance_plotting")
+        meta_dir = os.path.join(self.here.checkpoints, "meta_params_plotting")
+        for directory in [params_dir, perf_dir, meta_dir]:
+            os.makedirs(directory, exist_ok=True)
+
+        parameter_columns = ["resource"] + self.parameter_names
+        performance_columns = [
+            "resource",
+            "response",
+            "response_lower",
+            "response_upper",
+        ]
+        performance_optional_columns = ["count"]
+
+        manifest = {
+            "baseline_name": self.baseline.name,
+            "parameter_names": list(self.parameter_names),
+            "response_key": self.response_key,
+            "experiments": [],
+        }
+
+        params_df, eval_df = self.baseline.evaluate()
+        self._write_plotting_csv(
+            params_df,
+            os.path.join(params_dir, "baseline.csv"),
+            required_columns=parameter_columns,
+        )
+        self._write_plotting_csv(
+            eval_df,
+            os.path.join(perf_dir, "baseline.csv"),
+            required_columns=performance_columns,
+            optional_columns=performance_optional_columns,
+        )
+
+        for experiment in self.experiments:
+            if monotone and hasattr(experiment, "evaluate_monotone"):
+                res = experiment.evaluate_monotone()
+            else:
+                res = experiment.evaluate()
+
+            params_df = res[0]
+            eval_df = res[1]
+            self._write_plotting_csv(
+                params_df,
+                os.path.join(params_dir, f"{experiment.name}.csv"),
+                required_columns=parameter_columns,
+            )
+            if len(res) == 3:
+                self._write_plotting_csv(
+                    res[2],
+                    os.path.join(params_dir, f"{experiment.name}_preproc.csv"),
+                    required_columns=parameter_columns,
+                )
+
+            self._write_plotting_csv(
+                eval_df,
+                os.path.join(perf_dir, f"{experiment.name}.csv"),
+                required_columns=performance_columns,
+                optional_columns=performance_optional_columns,
+            )
+
+            experiment_manifest = {
+                "name": experiment.name,
+                "has_preprocessed_params": len(res) == 3,
+                "has_meta": hasattr(experiment, "meta_params"),
+                "meta_parameter_names": list(
+                    getattr(experiment, "meta_parameter_names", [])
+                ),
+                "meta_resource": getattr(experiment, "resource", "TotalBudget"),
+                "has_preprocessed_meta": hasattr(experiment, "preproc_meta_params"),
+            }
+
+            if hasattr(experiment, "meta_params"):
+                meta_resource = experiment_manifest["meta_resource"]
+                meta_columns = [meta_resource] + experiment_manifest[
+                    "meta_parameter_names"
+                ]
+                meta_params = experiment.meta_params.copy()
+                if meta_resource in meta_params.columns:
+                    meta_params.sort_values(by=meta_resource, inplace=True)
+                self._write_plotting_csv(
+                    meta_params,
+                    os.path.join(meta_dir, f"{experiment.name}.csv"),
+                    required_columns=meta_columns,
+                    resource_column=meta_resource,
+                )
+
+            if hasattr(experiment, "preproc_meta_params"):
+                meta_resource = experiment_manifest["meta_resource"]
+                meta_columns = [meta_resource] + experiment_manifest[
+                    "meta_parameter_names"
+                ]
+                preproc_meta_params = experiment.preproc_meta_params.copy()
+                if meta_resource in preproc_meta_params.columns:
+                    preproc_meta_params.sort_values(by=meta_resource, inplace=True)
+                self._write_plotting_csv(
+                    preproc_meta_params,
+                    os.path.join(meta_dir, f"{experiment.name}_preproc.csv"),
+                    required_columns=meta_columns,
+                    resource_column=meta_resource,
+                )
+
+            manifest["experiments"].append(experiment_manifest)
+
+        manifest_path = os.path.join(self.here.checkpoints, "plotting_manifest.json")
+        with open(manifest_path, "w", encoding="utf-8") as fh:
+            json.dump(manifest, fh, indent=2)
+
+        return manifest
+
+    def initPlotting(self, export_csvs=True, monotone=False):
         """
         Sets up plotting - this should be run after all experiments are run
         """
-        self.plots = Plotting(self)
+        if export_csvs:
+            self.export_plot_csvs(monotone=monotone)
+        self.plots = Plotting(self.here.checkpoints)

--- a/src/stochastic_benchmark.py
+++ b/src/stochastic_benchmark.py
@@ -11,6 +11,7 @@ import logging
 import bootstrap
 import df_utils
 import interpolate
+import plotting as plotting_module
 from plotting import *
 import stats
 import success_metrics
@@ -803,16 +804,25 @@ class stochastic_benchmark:
         )
         csv_df.to_csv(path, index=False)
 
-    def export_plot_csvs(self, monotone=False):
+    def export_plot_csvs(self, monotone=None):
         """
         Export the CSV files used by the plotting module.
 
         This separates plot rendering from in-memory benchmark objects. After this
         method runs, ``plotting.Plotting`` can recreate plots from the checkpoint
         directory alone.
+
+        Parameters
+        ----------
+        monotone : bool, optional
+            If provided, controls whether experiment CSVs are exported from
+            ``evaluate_monotone()`` when available. If omitted, this preserves the
+            legacy ``plotting.monotone`` module-level switch.
         """
         if not hasattr(self, "baseline"):
             raise AttributeError("run_baseline() must be called before exporting plots")
+        if monotone is None:
+            monotone = plotting_module.monotone
 
         params_dir = os.path.join(self.here.checkpoints, "params_plotting")
         perf_dir = os.path.join(self.here.checkpoints, "performance_plotting")
@@ -925,9 +935,19 @@ class stochastic_benchmark:
 
         return manifest
 
-    def initPlotting(self, export_csvs=True, monotone=False):
+    def initPlotting(self, export_csvs=True, monotone=None):
         """
-        Sets up plotting - this should be run after all experiments are run
+        Sets up plotting - this should be run after all experiments are run.
+
+        Parameters
+        ----------
+        export_csvs : bool, optional
+            Whether to export plotting CSVs before constructing the plotting
+            helper.
+        monotone : bool, optional
+            If provided, controls whether exported experiment curves use
+            ``evaluate_monotone()`` when available. If omitted, this preserves
+            the legacy ``plotting.monotone`` module-level switch.
         """
         if export_csvs:
             self.export_plot_csvs(monotone=monotone)

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -12,6 +12,7 @@ TESTS_DIR = os.path.dirname(__file__)
 SRC_PATH = os.path.abspath(os.path.join(TESTS_DIR, os.pardir, "src"))
 sys.path.insert(0, SRC_PATH)
 
+import plotting
 import stochastic_benchmark
 from plotting import Plotting
 
@@ -51,6 +52,21 @@ class FakeProjectionExperiment:
         )
         preproc_params = pd.DataFrame(
             {"resource": [10, 20], "alpha": [0.12, 0.22]}
+        )
+        return params_df, eval_df, preproc_params
+
+    def evaluate_monotone(self):
+        params_df = pd.DataFrame({"resource": [10, 20], "alpha": [0.17, 0.27]})
+        eval_df = pd.DataFrame(
+            {
+                "resource": [10, 20],
+                "response": [0.85, 0.9],
+                "response_lower": [0.8, 0.85],
+                "response_upper": [0.9, 0.95],
+            }
+        )
+        preproc_params = pd.DataFrame(
+            {"resource": [10, 20], "alpha": [0.14, 0.24]}
         )
         return params_df, eval_df, preproc_params
 
@@ -157,6 +173,64 @@ def test_init_plotting_exports_csvs_and_reads_from_checkpoint_dir(tmp_path):
     meta_figs, meta_axes = bench.plots.plot_meta_parameters()
     assert set(meta_axes["RandomSearch"]) == {"ExploreFrac", "tau"}
 
+    together_fig, together_axes = bench.plots.plot_parameters_together()
+    assert set(together_axes) == {"alpha"}
+
+    separate_figs, separate_axes = bench.plots.plot_parameters_separate()
+    assert set(separate_axes) == {"alpha"}
+
+    distance_fig, distance_ax = bench.plots.plot_parameters_distance()
+    assert distance_ax.get_ylabel() == "distance_scaled"
+
     plt.close(fig)
     for fig in meta_figs["RandomSearch"].values():
         plt.close(fig)
+    plt.close(together_fig)
+    for fig in separate_figs.values():
+        plt.close(fig)
+    plt.close(distance_fig)
+
+
+def test_direct_plotting_constructor_exports_from_benchmark_object(tmp_path):
+    bench = _benchmark_with_fake_results(tmp_path)
+
+    plots = Plotting(bench)
+
+    assert isinstance(plots, Plotting)
+    assert plots.parameter_names == ["alpha"]
+    assert os.path.exists(
+        os.path.join(bench.here.checkpoints, "performance_plotting", "baseline.csv")
+    )
+
+    fig, ax = plots.plot_performance()
+    assert ax.get_ylabel() == "PerfRatio"
+    plt.close(fig)
+
+
+def test_init_plotting_uses_legacy_monotone_switch_when_unspecified(tmp_path):
+    bench = _benchmark_with_fake_results(tmp_path)
+    previous_monotone = plotting.monotone
+
+    try:
+        plotting.monotone = True
+        bench.initPlotting()
+    finally:
+        plotting.monotone = previous_monotone
+
+    projection_perf = pd.read_csv(
+        os.path.join(
+            bench.here.checkpoints,
+            "performance_plotting",
+            "Projection from TrainingStats.csv",
+        )
+    )
+    projection_params = pd.read_csv(
+        os.path.join(
+            bench.here.checkpoints,
+            "params_plotting",
+            "Projection from TrainingStats.csv",
+        )
+    )
+
+    assert projection_perf["response"].tolist() == [0.85, 0.9]
+    assert projection_params["alpha"].tolist() == [0.17, 0.27]

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -1,0 +1,162 @@
+import json
+import os
+import sys
+
+import matplotlib
+import pandas as pd
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+
+TESTS_DIR = os.path.dirname(__file__)
+SRC_PATH = os.path.abspath(os.path.join(TESTS_DIR, os.pardir, "src"))
+sys.path.insert(0, SRC_PATH)
+
+import stochastic_benchmark
+from plotting import Plotting
+
+
+class FakeBaseline:
+    name = "VirtualBest"
+
+    def evaluate(self):
+        params_df = pd.DataFrame(
+            {"alpha": [0.1, 0.2]},
+            index=pd.Index([10, 20], name="resource"),
+        )
+        eval_df = pd.DataFrame(
+            {
+                "resource": [10, 20],
+                "response": [0.5, 0.7],
+                "response_lower": [0.4, 0.6],
+                "response_upper": [0.6, 0.8],
+                "count": [2, 2],
+            }
+        )
+        return params_df, eval_df
+
+
+class FakeProjectionExperiment:
+    name = "Projection from TrainingStats"
+
+    def evaluate(self):
+        params_df = pd.DataFrame({"resource": [10, 20], "alpha": [0.15, 0.25]})
+        eval_df = pd.DataFrame(
+            {
+                "resource": [10, 20],
+                "response": [0.45, 0.65],
+                "response_lower": [0.35, 0.55],
+                "response_upper": [0.55, 0.75],
+            }
+        )
+        preproc_params = pd.DataFrame(
+            {"resource": [10, 20], "alpha": [0.12, 0.22]}
+        )
+        return params_df, eval_df, preproc_params
+
+
+class FakeMetaExperiment:
+    name = "RandomSearch"
+    meta_parameter_names = ["ExploreFrac", "tau"]
+    resource = "TotalBudget"
+    meta_params = pd.DataFrame(
+        {
+            "TotalBudget": [20, 10],
+            "ExplorationBudget": [4, 1],
+            "ExploreFrac": [0.2, 0.1],
+            "tau": [5, 2],
+        }
+    )
+    preproc_meta_params = pd.DataFrame(
+        {
+            "TotalBudget": [10, 20],
+            "ExplorationBudget": [2, 6],
+            "ExploreFrac": [0.2, 0.3],
+            "tau": [3, 6],
+        }
+    )
+
+    def evaluate(self):
+        params_df = pd.DataFrame({"resource": [10, 20], "alpha": [0.3, 0.4]})
+        eval_df = pd.DataFrame(
+            {
+                "resource": [10, 20],
+                "response": [0.4, 0.6],
+                "response_lower": [0.3, 0.5],
+                "response_upper": [0.5, 0.7],
+            }
+        )
+        return params_df, eval_df
+
+
+def _benchmark_with_fake_results(tmp_path):
+    bench = stochastic_benchmark.stochastic_benchmark(
+        ["alpha"],
+        here=tmp_path,
+        response_key="PerfRatio",
+        recover=False,
+    )
+    bench.baseline = FakeBaseline()
+    bench.experiments = [FakeProjectionExperiment(), FakeMetaExperiment()]
+    return bench
+
+
+def test_export_plot_csvs_writes_resource_columns_and_manifest(tmp_path):
+    bench = _benchmark_with_fake_results(tmp_path)
+
+    manifest = bench.export_plot_csvs()
+
+    checkpoints = bench.here.checkpoints
+    baseline_params = pd.read_csv(
+        os.path.join(checkpoints, "params_plotting", "baseline.csv")
+    )
+    random_meta = pd.read_csv(
+        os.path.join(checkpoints, "meta_params_plotting", "RandomSearch.csv")
+    )
+
+    assert baseline_params.columns.tolist() == ["resource", "alpha"]
+    assert "Unnamed: 0" not in baseline_params.columns
+    assert random_meta.columns.tolist() == ["TotalBudget", "ExploreFrac", "tau"]
+    assert random_meta["TotalBudget"].tolist() == [10, 20]
+    assert manifest["baseline_name"] == "VirtualBest"
+    assert manifest["parameter_names"] == ["alpha"]
+    assert manifest["response_key"] == "PerfRatio"
+    assert [exp["name"] for exp in manifest["experiments"]] == [
+        "Projection from TrainingStats",
+        "RandomSearch",
+    ]
+
+    manifest_path = os.path.join(checkpoints, "plotting_manifest.json")
+    with open(manifest_path, "r", encoding="utf-8") as fh:
+        assert json.load(fh) == manifest
+
+
+def test_init_plotting_exports_csvs_and_reads_from_checkpoint_dir(tmp_path):
+    bench = _benchmark_with_fake_results(tmp_path)
+
+    bench.initPlotting()
+
+    assert isinstance(bench.plots, Plotting)
+    assert bench.plots.parameter_names == ["alpha"]
+    assert bench.plots.response_key == "PerfRatio"
+    assert bench.plots.experiment_names == [
+        "Projection from TrainingStats",
+        "RandomSearch",
+    ]
+
+    fig, ax = bench.plots.plot_performance()
+    assert ax.get_ylabel() == "PerfRatio"
+    assert os.path.exists(
+        os.path.join(
+            bench.here.checkpoints,
+            "params_plotting",
+            "Projection from TrainingStats_preproc.csv",
+        )
+    )
+
+    meta_figs, meta_axes = bench.plots.plot_meta_parameters()
+    assert set(meta_axes["RandomSearch"]) == {"ExploreFrac", "tau"}
+
+    plt.close(fig)
+    for fig in meta_figs["RandomSearch"].values():
+        plt.close(fig)

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -117,6 +117,24 @@ def _benchmark_with_fake_results(tmp_path):
     return bench
 
 
+def _projection_plot_csvs(bench):
+    projection_perf = pd.read_csv(
+        os.path.join(
+            bench.here.checkpoints,
+            "performance_plotting",
+            "Projection from TrainingStats.csv",
+        )
+    )
+    projection_params = pd.read_csv(
+        os.path.join(
+            bench.here.checkpoints,
+            "params_plotting",
+            "Projection from TrainingStats.csv",
+        )
+    )
+    return projection_perf, projection_params
+
+
 def test_export_plot_csvs_writes_resource_columns_and_manifest(tmp_path):
     bench = _benchmark_with_fake_results(tmp_path)
 
@@ -217,20 +235,28 @@ def test_init_plotting_uses_legacy_monotone_switch_when_unspecified(tmp_path):
     finally:
         plotting.monotone = previous_monotone
 
-    projection_perf = pd.read_csv(
-        os.path.join(
-            bench.here.checkpoints,
-            "performance_plotting",
-            "Projection from TrainingStats.csv",
-        )
-    )
-    projection_params = pd.read_csv(
-        os.path.join(
-            bench.here.checkpoints,
-            "params_plotting",
-            "Projection from TrainingStats.csv",
-        )
-    )
+    projection_perf, projection_params = _projection_plot_csvs(bench)
 
     assert projection_perf["response"].tolist() == [0.85, 0.9]
     assert projection_params["alpha"].tolist() == [0.17, 0.27]
+
+
+def test_init_plotting_explicit_monotone_overrides_legacy_switch(tmp_path):
+    previous_monotone = plotting.monotone
+
+    try:
+        plotting.monotone = False
+        monotone_bench = _benchmark_with_fake_results(tmp_path / "monotone")
+        monotone_bench.initPlotting(monotone=True)
+        projection_perf, projection_params = _projection_plot_csvs(monotone_bench)
+        assert projection_perf["response"].tolist() == [0.85, 0.9]
+        assert projection_params["alpha"].tolist() == [0.17, 0.27]
+
+        plotting.monotone = True
+        raw_bench = _benchmark_with_fake_results(tmp_path / "raw")
+        raw_bench.initPlotting(monotone=False)
+        projection_perf, projection_params = _projection_plot_csvs(raw_bench)
+        assert projection_perf["response"].tolist() == [0.45, 0.65]
+        assert projection_params["alpha"].tolist() == [0.15, 0.25]
+    finally:
+        plotting.monotone = previous_monotone


### PR DESCRIPTION
## Summary

Supersedes bernalde/stochastic-benchmark#25 and addresses usra-riacs/stochastic-benchmark#33.

This migrates the fork PR onto current upstream `main` and keeps the intended behavior while preserving existing notebook workflows:

- add `stochastic_benchmark.export_plot_csvs()` to write plotting data into checkpoint CSV directories;
- change `Plotting` to render from exported CSV files instead of requiring a live `stochastic_benchmark` object;
- write a small `plotting_manifest.json` so labels, response keys, parameter names, and meta-parameter names survive the object-to-CSV boundary;
- keep `sb.initPlotting()` usable for existing examples by exporting CSVs before constructing the CSV-backed `Plotting` helper;
- avoid leaking dataframe index columns into CSV-based parameter inference;
- add focused tests for CSV export, manifest writing, and CSV-backed plotting.

## Validation

- `~/.local/bin/uv run --no-project --with-requirements requirements.txt --with-requirements requirements-dev.txt python -m pytest tests/test_plotting.py tests/test_smoke.py`
- `~/.local/bin/uv run --no-project --with-requirements requirements.txt --with-requirements requirements-dev.txt python run_tests.py unit`
- `~/.local/bin/uv run --no-project --with-requirements requirements.txt --with-requirements requirements-dev.txt python run_tests.py integration`

Tutorial notebooks executed successfully against this branch with `PYTHONPATH` pointing at this checkout's `src`:

- `examples/TenSolver/TenSolver.ipynb`
- `examples/QAOA_iterative/qaoa_demo.ipynb`
- `examples/QAOA_multipleSplits/qaoa_multiple_splits.ipynb`
- `examples/Simulated_Annealing/simulated_annealing.ipynb`
- `examples/wishart_n_50_alpha_0.5/wishart_n_50_alpha_0.50.ipynb`
- `examples/wishart_n_50_alpha_0.5/wishart_n_50_alpha_0.50_split.ipynb`

`examples/QEDC_to_WS_conversion/conversion.ipynb` remains excluded because it is not self-contained in this repository; that blocker is tracked separately in #54.

Closes #33.
