### PR TITLE
Decouple Wishart analysis imports

### DIFF
--- a/examples/wishart_n_50_alpha_0.5/README.md
+++ b/examples/wishart_n_50_alpha_0.5/README.md
@@ -10,10 +10,11 @@ This example has different dependencies depending on what you want to do:
 
 #### For Running Analysis Only (using pre-generated data):
 ```bash
+pip install -r ../../requirements.txt
 pip install -r ../../requirements-examples.txt
 ```
 
-This installs:
+This installs the core stochastic-benchmark dependencies plus:
 - **scikit-learn** - Required for polynomial regression models in parameter recommendation
 
 #### For Generating New Experimental Data:
@@ -23,7 +24,7 @@ If you want to generate new data (not just analyze existing results), you also n
 
 These generation-only dependencies are imported lazily by `wishart_runs.py`, so importing the analysis helpers in `wishart_ws.py` does not require them.
 
-The analysis notebook (`wishart_n_50_alpha_0.50.ipynb`) only requires scikit-learn and works with pre-generated data files.
+The analysis notebook (`wishart_n_50_alpha_0.50.ipynb`) requires the core stochastic-benchmark dependencies and scikit-learn, and works with pre-generated data files without importing PySA-only generation paths.
 
 ### Data Files
 
@@ -48,6 +49,7 @@ wishart_n_50_alpha_0.5/
 
 2. **Install dependencies**:
    ```bash
+   pip install -r ../../requirements.txt
    pip install -r ../../requirements-examples.txt
    ```
 

--- a/examples/wishart_n_50_alpha_0.5/README.md
+++ b/examples/wishart_n_50_alpha_0.5/README.md
@@ -19,7 +19,9 @@ This installs:
 #### For Generating New Experimental Data:
 If you want to generate new data (not just analyze existing results), you also need:
 - **pysa** - For running simulated annealing experiments
-- Note: `wishart_runs.py` handles missing pysa gracefully with a try/except
+- **hyperopt** - For running the Hyperopt-driven parameter search
+
+These generation-only dependencies are imported lazily by `wishart_runs.py`, so importing the analysis helpers in `wishart_ws.py` does not require them.
 
 The analysis notebook (`wishart_n_50_alpha_0.50.ipynb`) only requires scikit-learn and works with pre-generated data files.
 
@@ -67,6 +69,7 @@ wishart_n_50_alpha_0.5/
 
 - **wishart_ws.py**: Contains `stoch_bench_setup()` which initializes the benchmarking framework with Wishart-specific configuration
 - **wishart_runs.py**: Functions for running QAOA/simulated annealing experiments on Wishart instances
+- **wishart_paths.py**: Shared path and filename helpers used by both analysis and generation code
 - **wishart_n_50_alpha_0.50.ipynb**: Main analysis notebook with visualization
 
 ## Notes

--- a/examples/wishart_n_50_alpha_0.5/wishart_paths.py
+++ b/examples/wishart_n_50_alpha_0.5/wishart_paths.py
@@ -1,0 +1,19 @@
+import os
+
+
+alpha = '0.50'
+
+# Use relative paths based on this script's location.
+script_dir = os.path.dirname(os.path.abspath(__file__))
+datapath = os.path.join(script_dir, 'data')
+rerun_datapath = os.path.join(script_dir, 'rerun_data')
+
+
+def logname(instance_num, sweeps, replicas, pcold, phot, rerun=False):
+    log = 'inst={}_pcold={:.2f}_phot={:.1f}_replicas={}_sweeps={}.pkl'.format(
+        instance_num, pcold, phot, replicas, sweeps)
+    obj = 'obj_inst={}_pcold={:.2f}_phot={:.1f}_replicas={}_sweeps={}.pkl'.format(
+        instance_num, pcold, phot, replicas, sweeps)
+    if rerun:
+        return os.path.join(rerun_datapath, log), os.path.join(rerun_datapath, obj)
+    return os.path.join(datapath, log), os.path.join(datapath, obj)

--- a/examples/wishart_n_50_alpha_0.5/wishart_runs.py
+++ b/examples/wishart_n_50_alpha_0.5/wishart_runs.py
@@ -1,29 +1,19 @@
 import dill
-from hyperopt import fmin, tpe, hp, STATUS_OK, Trials
-from hyperopt.fmin import generate_trials_to_calculate
 import math
 import numpy as np
 import os
 import pandas as pd
-try:
-    from pysa.sa import Solver
-except:
-    print('no pysa found')
 from scipy.sparse import csr_matrix
 import sys
 from tqdm import tqdm
 import time
 
+from wishart_paths import alpha, datapath, rerun_datapath, logname
+
 N = 50
-alpha = '0.50'
 n_reads = 1001 #TODO change this if you want
 float_type = 'float32'
 penalty = 1e6
-
-# Use relative paths based on this script's location
-script_dir = os.path.dirname(os.path.abspath(__file__))
-datapath = os.path.join(script_dir, 'data')  # Relative path for portability
-rerun_datapath = os.path.join(script_dir, 'rerun_data')  # Relative path for portability
 
 class seen_result:
     def __init__(self):
@@ -34,13 +24,15 @@ class seen_result:
     def to_dateframe(self):
         return
 
-def logname(instance_num, sweeps, replicas, pcold, phot, rerun=False):
-    log = 'inst={}_pcold={:.2f}_phot={:.1f}_replicas={}_sweeps={}.pkl'.format(instance_num, pcold, phot, replicas, sweeps)
-    obj = 'obj_inst={}_pcold={:.2f}_phot={:.1f}_replicas={}_sweeps={}.pkl'.format(instance_num, pcold, phot, replicas, sweeps) 
-    if rerun:
-        return os.path.join(rerun_datapath, log), os.path.join(rerun_datapath, obj)
-    else:
-        return os.path.join(datapath, log), os.path.join(datapath, obj)
+def _pysa_solver():
+    try:
+        from pysa.sa import Solver
+    except ImportError as exc:
+        raise ImportError(
+            'PySA is required to generate or rerun Wishart experimental data. '
+            'Install PySA before calling run_pysa() or rerun_pysa().'
+        ) from exc
+    return Solver
 
 def sol_to_bitstring(sol):
     bitstring = ''.join([str(int(x)) for x in sol])
@@ -120,6 +112,7 @@ def run_pysa(args, instance_num, pbar=None):
             min_temp = 2 * np.min(np.abs(qubo[np.nonzero(qubo)])) / np.log(100/pcold)
     #         min_temp_cal = 2*min(sum(abs(i) for i in qubo)) / np.log(100/p_cold)
             max_temp = 2 * np.max(np.abs(qubo.A).sum(axis=0)) / np.log(100/phot)
+            Solver = _pysa_solver()
             solver = Solver(problem=qubo.A, problem_type='ising', float_type=float_type)
             res = solver.metropolis_update(
                 num_sweeps = sweeps,
@@ -141,6 +134,7 @@ def run_pysa(args, instance_num, pbar=None):
         min_temp = 2 * np.min(np.abs(qubo[np.nonzero(qubo)])) / np.log(100/pcold)
 #         min_temp_cal = 2*min(sum(abs(i) for i in qubo)) / np.log(100/p_cold)
         max_temp = 2 * np.max(np.abs(qubo.A).sum(axis=0)) / np.log(100/phot)
+        Solver = _pysa_solver()
         solver = Solver(problem=qubo.A, problem_type='ising', float_type=float_type)
         res = solver.metropolis_update(
             num_sweeps = sweeps,
@@ -192,6 +186,7 @@ def rerun_pysa(params, instance_num):
         min_temp = 2 * np.min(np.abs(qubo[np.nonzero(qubo)])) / np.log(100/pcold)
 #         min_temp_cal = 2*min(sum(abs(i) for i in qubo)) / np.log(100/p_cold)
         max_temp = 2 * np.max(np.abs(qubo.A).sum(axis=0)) / np.log(100/phot)
+        Solver = _pysa_solver()
         solver = Solver(problem=qubo.A, problem_type='ising', float_type=float_type)
         res = solver.metropolis_update(
             num_sweeps = sweeps,
@@ -248,6 +243,9 @@ def process_pysa(res, gs_energy):
     return norm_score, mean_time, seen
 
 def run_hyperopt(h, hpo_trial, instance_num):
+    from hyperopt import fmin, tpe, hp
+    from hyperopt.fmin import generate_trials_to_calculate
+
     # TODO set your parameters space
     spaceVar = {'sweeps': hp.qloguniform('sweeps', 0, 4, 1),
                 'replicas': hp.quniform('replicas', 1, 16, 1),

--- a/examples/wishart_n_50_alpha_0.5/wishart_ws.py
+++ b/examples/wishart_n_50_alpha_0.5/wishart_ws.py
@@ -6,13 +6,10 @@ from multiprocess import Pool
 import numpy as np
 import os
 import pandas as pd
-from sklearn.compose import TransformedTargetRegressor
-from sklearn.linear_model import LinearRegression
-from sklearn.preprocessing import PolynomialFeatures
-from sklearn.pipeline import make_pipeline
 import sys
 from tqdm import tqdm
 import warnings
+from wishart_paths import logname
 
 # Filter known third-party warnings
 warnings.filterwarnings('ignore', message='pkg_resources is deprecated')
@@ -28,13 +25,25 @@ import stochastic_benchmark
 import success_metrics
 from utils_ws import *
 
-import wishart_runs #TODO I need to find the file I sent previous -> add to path if necessary
-
 alpha = '0.50'
 # Set datadir relative to the current file location
 # This assumes the data is in rerun_data/ subdirectory of the example folder
 script_dir = os.path.dirname(os.path.abspath(__file__))
 datadir = os.path.join(script_dir, 'rerun_data')  # Use relative path for portability
+
+
+def _load_sklearn_tools():
+    try:
+        from sklearn.compose import TransformedTargetRegressor
+        from sklearn.linear_model import LinearRegression
+        from sklearn.preprocessing import PolynomialFeatures
+        from sklearn.pipeline import make_pipeline
+    except ImportError as exc:
+        raise ImportError(
+            'scikit-learn is required for Wishart parameter post-processing. '
+            'Install the example dependencies with `pip install -r ../../requirements-examples.txt`.'
+        ) from exc
+    return TransformedTargetRegressor, LinearRegression, PolynomialFeatures, make_pipeline
 
 
 def compress_order(df_single):
@@ -73,7 +82,7 @@ def instance_df(instance_num):
                 phot = np.maximum(0.1, np.round(hpoTrial.vals['phot'][idx], decimals=1))
                 
                 order = idx if idx >= hpo_offset else np.nan
-                df_filename, obj_filename = wishart_runs.logname(instance_num, sweeps, replicas, pcold, phot)
+                df_filename, obj_filename = logname(instance_num, sweeps, replicas, pcold, phot)
                 temp_df = pd.read_pickle(df_filename)
                 with open(obj_filename, 'rb') as f:
                     obj = dill.load(f)
@@ -109,6 +118,7 @@ def random_values(instance_num):
     return rv
 
 def postprocess_linear(recipe):
+    _, LinearRegression, _, _ = _load_sklearn_tools()
     x_range = (10**3, 10**6)
     post_recipe_dict = {}
     
@@ -128,6 +138,7 @@ def postprocess_linear(recipe):
     return pred_recipe
 
 def postprocess_polynomial(recipe, deg):
+    _, LinearRegression, PolynomialFeatures, make_pipeline = _load_sklearn_tools()
     post_recipe_dict = {}
     post_recipe_dict['resource'] = np.array(recipe['resource'].copy())
     parameter_names = ['sweeps', 'replicas', 'pcold', 'phot']
@@ -141,6 +152,7 @@ def postprocess_polynomial(recipe, deg):
     return pred_recipe
         
 def postprocess_custom(recipe):
+    TransformedTargetRegressor, LinearRegression, _, _ = _load_sklearn_tools()
     post_recipe_dict = {}
     post_recipe_dict['resource'] = np.array(recipe['resource'].copy())
     parameter_names = ['sweeps', 'replicas', 'pcold', 'phot']
@@ -354,6 +366,8 @@ def compress_experiments(parameters_list):
     return parameters_dict
 
 def run_experiments(parameters_list, testing_instances):
+    import wishart_runs
+
     parameters_dict = compress_experiments(parameters_list)
     results_dict = {k:experiment_results(v) for k, v, in parameters_dict.items()}
 
@@ -458,4 +472,3 @@ def main():
 
 if __name__ == '__main__':
     main()
-

--- a/tests/test_wishart_imports.py
+++ b/tests/test_wishart_imports.py
@@ -1,0 +1,99 @@
+import ast
+import importlib
+import sys
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+EXAMPLE_DIR = REPO_ROOT / "examples" / "wishart_n_50_alpha_0.5"
+BLOCKED_GENERATION_MODULES = ("hyperopt", "pysa")
+
+
+class BlockGenerationImports:
+    def find_spec(self, fullname, path=None, target=None):
+        if any(
+            fullname == module or fullname.startswith(f"{module}.")
+            for module in BLOCKED_GENERATION_MODULES
+        ):
+            raise ModuleNotFoundError(
+                f"No module named '{fullname}'",
+                name=fullname,
+            )
+        return None
+
+
+def _tree(filename):
+    return ast.parse((EXAMPLE_DIR / filename).read_text())
+
+
+def _top_level_import_names(filename):
+    names = []
+    for node in _tree(filename).body:
+        if isinstance(node, ast.Import):
+            names.extend(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom):
+            names.append(node.module)
+    return names
+
+
+def _clear_example_modules(monkeypatch):
+    prefixes = (
+        "wishart_paths",
+        "wishart_runs",
+        "wishart_ws",
+        *BLOCKED_GENERATION_MODULES,
+    )
+    for name in list(sys.modules):
+        if any(name == prefix or name.startswith(f"{prefix}.") for prefix in prefixes):
+            monkeypatch.delitem(sys.modules, name, raising=False)
+
+
+def _import_with_generation_deps_blocked(module_name, monkeypatch):
+    monkeypatch.syspath_prepend(str(REPO_ROOT / "src"))
+    monkeypatch.syspath_prepend(str(EXAMPLE_DIR))
+    _clear_example_modules(monkeypatch)
+    monkeypatch.setattr(sys, "meta_path", [BlockGenerationImports(), *sys.meta_path])
+
+    try:
+        return importlib.import_module(module_name)
+    except ModuleNotFoundError as exc:
+        missing = exc.name or ""
+        if any(
+            missing == module or missing.startswith(f"{module}.")
+            for module in BLOCKED_GENERATION_MODULES
+        ):
+            pytest.fail(f"{module_name} imported generation dependency {missing!r}")
+        pytest.skip(f"Missing non-generation dependency required by the example: {missing}")
+
+
+def test_wishart_ws_has_no_top_level_generation_imports():
+    imports = _top_level_import_names("wishart_ws.py")
+
+    assert "wishart_runs" not in imports
+    assert "hyperopt" not in imports
+    assert "pysa" not in imports
+
+
+def test_wishart_runs_has_no_top_level_hyperopt_or_pysa_imports():
+    imports = _top_level_import_names("wishart_runs.py")
+
+    assert "hyperopt" not in imports
+    assert "hyperopt.fmin" not in imports
+    assert "pysa.sa" not in imports
+
+
+def test_wishart_ws_import_does_not_require_generation_dependencies(monkeypatch):
+    wishart_ws = _import_with_generation_deps_blocked("wishart_ws", monkeypatch)
+
+    assert hasattr(wishart_ws, "stoch_bench_setup")
+    assert "wishart_runs" not in sys.modules
+
+
+def test_wishart_runs_import_does_not_require_generation_dependencies(monkeypatch):
+    wishart_runs = _import_with_generation_deps_blocked("wishart_runs", monkeypatch)
+
+    df_name, obj_name = wishart_runs.logname(1, 10, 2, 1.0, 50.0)
+    assert df_name.endswith("inst=1_pcold=1.00_phot=50.0_replicas=2_sweeps=10.pkl")
+    assert obj_name.endswith("obj_inst=1_pcold=1.00_phot=50.0_replicas=2_sweeps=10.pkl")


### PR DESCRIPTION
## Summary

- Extract Wishart path and filename helpers into `wishart_paths.py` so analysis code can use `logname()` without importing generation code.
- Remove eager `wishart_runs` imports from `wishart_ws.py`; generation reruns are imported only inside `run_experiments()`.
- Move Hyperopt and PySA imports into the functions that actually need them, and document analysis-only versus data-generation dependencies.
- Add regression tests for top-level Wishart imports and blocked Hyperopt/PySA imports.

## Tests run

- `git diff --check` - passed.
- `python -m py_compile examples/wishart_n_50_alpha_0.5/wishart_paths.py examples/wishart_n_50_alpha_0.5/wishart_runs.py examples/wishart_n_50_alpha_0.5/wishart_ws.py tests/test_wishart_imports.py` - passed.
- `pytest tests/test_wishart_imports.py -q -rs` - passed with `2 passed, 2 skipped`; the runtime import checks skipped locally because this Python 3.13 environment is missing the non-generation example dependency `dill`.

## Notes about tests not run

- `pytest tests -q` was attempted, but collection failed before running the suite because the local environment is missing project dependencies such as `multiprocess`. CI installs dependencies from `requirements.txt` and should exercise the runtime import checks.

Closes #57
