### PR TITLE
Add tutorial notebook smoke CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,6 +108,38 @@ jobs:
           echo "No integration tests found"
         fi
 
+  tutorial-smoke:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.10'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+        pip install -r requirements-dev.txt
+        pip install -r requirements-examples.txt
+        pip install -e .
+
+    - name: Execute self-contained tutorial notebooks
+      run: |
+        export PYTHONPATH="${PYTHONPATH}:${PWD}/src"
+        python scripts/verify_tutorials.py --output-dir executed-notebooks
+
+    - name: Upload executed tutorial notebooks
+      uses: actions/upload-artifact@v4
+      if: always()
+      with:
+        name: executed-tutorial-notebooks
+        path: executed-notebooks/
+        retention-days: 30
+
   coverage-summary:
     runs-on: ubuntu-latest
     needs: test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,9 +53,9 @@ jobs:
         pytest tests/ -v --cov=src --cov-report=xml --cov-report=html --cov-report=term
     
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v5
       with:
-        file: ./coverage.xml
+        files: ./coverage.xml
         flags: unittests
         name: codecov-umbrella
         fail_ci_if_error: false

--- a/CI-TESTING.md
+++ b/CI-TESTING.md
@@ -110,6 +110,10 @@ After running tests, coverage reports are generated:
   ```
 - **XML**: `coverage.xml` (for tools like codecov)
 
+## Codecov Setup
+
+GitHub Actions uploads `coverage.xml` with `codecov/codecov-action@v5`. For reliable upstream uploads and PR comments, install the Codecov GitHub App for `usra-riacs/stochastic-benchmark`. If Codecov requires authenticated uploads for protected branches, add `CODECOV_TOKEN` as a repository secret and wire it into the upload step.
+
 ## Troubleshooting
 
 ### Import Errors

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ To run the same self-contained tutorial notebook smoke check used in CI:
 python scripts/verify_tutorials.py --output-dir executed-notebooks
 ```
 
-The manifest at `examples/tutorials.json` lists runnable notebooks and documents notebooks that are intentionally skipped because they require external setup.
+The manifest at `examples/tutorials.json` lists runnable notebooks and documents notebooks that are intentionally skipped because they require external setup or are too slow for the lightweight CI smoke job.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -131,6 +131,14 @@ After installing `requirements-examples.txt`, a notebook can be checked from the
 python -m jupyter nbconvert --to notebook --execute --inplace path/to/notebook.ipynb
 ```
 
+To run the same self-contained tutorial notebook smoke check used in CI:
+
+```bash
+python scripts/verify_tutorials.py --output-dir executed-notebooks
+```
+
+The manifest at `examples/tutorials.json` lists runnable notebooks and documents notebooks that are intentionally skipped because they require external setup.
+
 ## Documentation
 
 Use the root README as the entry point, then follow the focused documents for the part of the workflow you need:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Window Sticker - Stochastic Benchmark
 
 [![CI](https://github.com/bernalde/stochastic-benchmark/actions/workflows/ci.yml/badge.svg)](https://github.com/bernalde/stochastic-benchmark/actions/workflows/ci.yml)
-[![codecov](https://codecov.io/gh/bernalde/stochastic-benchmark/branch/main/graph/badge.svg)](https://codecov.io/gh/bernalde/stochastic-benchmark)
+[![codecov](https://codecov.io/gh/usra-riacs/stochastic-benchmark/branch/main/graph/badge.svg)](https://codecov.io/gh/usra-riacs/stochastic-benchmark)
 [![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/release/python-3100/)
 [![License](https://img.shields.io/github/license/bernalde/stochastic-benchmark)](LICENSE)
 

--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ python scripts/verify_tutorials.py --output-dir executed-notebooks
 ```
 
 The manifest at `examples/tutorials.json` lists runnable notebooks and documents notebooks that are intentionally skipped because they require external setup or are too slow for the lightweight CI smoke job.
+The smoke check executes copied notebook directories under the output directory, so generated plots, summaries, and caches are kept with the executed notebooks instead of modifying the source examples.
 
 ## Documentation
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -50,6 +50,19 @@ pytest tests/test_names.py -v
 pytest tests/ --cov=src --cov-report=html
 ```
 
+### Tutorial notebook smoke checks
+
+The CI tutorial smoke job executes the self-contained notebooks listed in
+`examples/tutorials.json` and writes executed copies to `executed-notebooks/`.
+Run the same check locally with:
+
+```bash
+python scripts/verify_tutorials.py --output-dir executed-notebooks
+```
+
+The manifest also lists notebooks that are intentionally skipped with a visible
+reason, such as tutorials that require external repositories or data.
+
 ## GitHub Actions CI/CD
 
 The repository includes automated testing via GitHub Actions:
@@ -58,6 +71,7 @@ The repository includes automated testing via GitHub Actions:
 - **Linting**: Code quality checks with flake8
 - **Coverage**: Automated coverage reporting via Codecov
 - **Integration Tests**: Cross-module functionality verification
+- **Tutorial Smoke Tests**: Self-contained notebooks execute on Python 3.10 and upload executed notebooks as artifacts
 
 ## Test Coverage
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -61,7 +61,8 @@ python scripts/verify_tutorials.py --output-dir executed-notebooks
 ```
 
 The manifest also lists notebooks that are intentionally skipped with a visible
-reason, such as tutorials that require external repositories or data.
+reason, such as tutorials that require external repositories, external data, or
+more runtime than the lightweight CI smoke job should use.
 
 ## GitHub Actions CI/CD
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -63,6 +63,9 @@ python scripts/verify_tutorials.py --output-dir executed-notebooks
 The manifest also lists notebooks that are intentionally skipped with a visible
 reason, such as tutorials that require external repositories, external data, or
 more runtime than the lightweight CI smoke job should use.
+Runnable notebooks are executed from copied notebook directories under the
+output directory, keeping generated plots, summaries, caches, and executed
+notebooks together without modifying the source `examples/` tree.
 
 ## GitHub Actions CI/CD
 

--- a/examples/tutorials.json
+++ b/examples/tutorials.json
@@ -23,7 +23,8 @@
     },
     {
       "path": "examples/wishart_n_50_alpha_0.5/wishart_n_50_alpha_0.50_split.ipynb",
-      "category": "self_contained"
+      "category": "slow",
+      "reason": "Self-contained but exceeds the lightweight GitHub Actions smoke timeout."
     },
     {
       "path": "examples/QEDC_to_WS_conversion/conversion.ipynb",

--- a/examples/tutorials.json
+++ b/examples/tutorials.json
@@ -18,7 +18,8 @@
     },
     {
       "path": "examples/wishart_n_50_alpha_0.5/wishart_n_50_alpha_0.50.ipynb",
-      "category": "self_contained"
+      "category": "slow",
+      "reason": "Self-contained but exceeds the lightweight GitHub Actions smoke timeout."
     },
     {
       "path": "examples/wishart_n_50_alpha_0.5/wishart_n_50_alpha_0.50_split.ipynb",

--- a/examples/tutorials.json
+++ b/examples/tutorials.json
@@ -1,0 +1,33 @@
+{
+  "notebooks": [
+    {
+      "path": "examples/TenSolver/TenSolver.ipynb",
+      "category": "self_contained"
+    },
+    {
+      "path": "examples/QAOA_iterative/qaoa_demo.ipynb",
+      "category": "self_contained"
+    },
+    {
+      "path": "examples/QAOA_multipleSplits/qaoa_multiple_splits.ipynb",
+      "category": "self_contained"
+    },
+    {
+      "path": "examples/Simulated_Annealing/simulated_annealing.ipynb",
+      "category": "self_contained"
+    },
+    {
+      "path": "examples/wishart_n_50_alpha_0.5/wishart_n_50_alpha_0.50.ipynb",
+      "category": "self_contained"
+    },
+    {
+      "path": "examples/wishart_n_50_alpha_0.5/wishart_n_50_alpha_0.50_split.ipynb",
+      "category": "self_contained"
+    },
+    {
+      "path": "examples/QEDC_to_WS_conversion/conversion.ipynb",
+      "category": "external",
+      "reason": "Requires external maxcut_benchmark code; tracked in issue #54."
+    }
+  ]
+}

--- a/scripts/verify_tutorials.py
+++ b/scripts/verify_tutorials.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import shutil
 import shlex
 import subprocess
 import sys
@@ -107,6 +108,36 @@ def build_nbconvert_command(
     ]
 
 
+def _is_relative_to(path: Path, parent: Path) -> bool:
+    try:
+        path.relative_to(parent)
+    except ValueError:
+        return False
+    return True
+
+
+def _prepare_tutorial_workspace(tutorial: Tutorial, root: Path, output_dir: Path) -> Path:
+    rel_path = tutorial.path.relative_to(root)
+    source_dir = tutorial.path.parent
+    workspace_dir = output_dir / rel_path.parent
+
+    resolved_workspace = workspace_dir.resolve()
+    resolved_source = source_dir.resolve()
+    if resolved_workspace == resolved_source or _is_relative_to(resolved_workspace, resolved_source):
+        raise ManifestError(
+            f"output workspace for {rel_path} must not be inside the source notebook directory"
+        )
+
+    if workspace_dir.exists():
+        shutil.rmtree(workspace_dir)
+    shutil.copytree(
+        source_dir,
+        workspace_dir,
+        ignore=shutil.ignore_patterns("__pycache__", ".ipynb_checkpoints"),
+    )
+    return workspace_dir / tutorial.path.name
+
+
 def _env_with_src_path(root: Path) -> dict[str, str]:
     env = os.environ.copy()
     src_path = str(root / "src")
@@ -131,16 +162,24 @@ def run_tutorials(
             print(f"SKIP {rel_path} ({tutorial.category}): {tutorial.reason}", flush=True)
             continue
 
-        tutorial_output_dir = output_dir / rel_path.parent
-        tutorial_output_dir.mkdir(parents=True, exist_ok=True)
-        command = build_nbconvert_command(tutorial.path, tutorial_output_dir, timeout)
-
         print(f"EXECUTE {rel_path}", flush=True)
         if dry_run:
+            tutorial_output_dir = output_dir / rel_path.parent
+            command = build_nbconvert_command(
+                tutorial_output_dir / tutorial.path.name,
+                tutorial_output_dir,
+                timeout,
+            )
             print(f"DRY-RUN {shlex.join(command)}", flush=True)
             continue
 
-        result = subprocess.run(command, cwd=root, env=env, check=False)
+        workspace_notebook = _prepare_tutorial_workspace(tutorial, root, output_dir)
+        command = build_nbconvert_command(
+            workspace_notebook,
+            workspace_notebook.parent,
+            timeout,
+        )
+        result = subprocess.run(command, cwd=workspace_notebook.parent, env=env, check=False)
         if result.returncode != 0:
             print(f"FAILED {rel_path} with exit code {result.returncode}", file=sys.stderr)
             return result.returncode
@@ -187,13 +226,17 @@ def main(argv: list[str] | None = None) -> int:
         print(f"ERROR: {exc}", file=sys.stderr)
         return 2
 
-    return run_tutorials(
-        tutorials=tutorials,
-        root=root,
-        output_dir=args.output_dir,
-        timeout=args.timeout,
-        dry_run=args.dry_run,
-    )
+    try:
+        return run_tutorials(
+            tutorials=tutorials,
+            root=root,
+            output_dir=args.output_dir,
+            timeout=args.timeout,
+            dry_run=args.dry_run,
+        )
+    except ManifestError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
 
 
 if __name__ == "__main__":

--- a/scripts/verify_tutorials.py
+++ b/scripts/verify_tutorials.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+"""Execute self-contained tutorial notebooks listed in the examples manifest."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shlex
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+RUN_CATEGORY = "self_contained"
+VALID_CATEGORIES = {RUN_CATEGORY, "external", "slow"}
+
+
+class ManifestError(ValueError):
+    """Raised when the tutorial manifest is invalid."""
+
+
+@dataclass(frozen=True)
+class Tutorial:
+    path: Path
+    category: str
+    reason: str = ""
+
+
+def repository_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def _entry_path(entry: dict, index: int) -> Path:
+    rel_path = entry.get("path")
+    if not isinstance(rel_path, str) or not rel_path:
+        raise ManifestError(f"manifest entry {index} must include a notebook path")
+
+    path = Path(rel_path)
+    if path.is_absolute() or ".." in path.parts:
+        raise ManifestError(f"manifest entry {index} path must stay inside the repository")
+    return path
+
+
+def _entry_category(entry: dict, index: int) -> tuple[str, str]:
+    category = entry.get("category")
+    reason = entry.get("reason", "")
+
+    if category not in VALID_CATEGORIES:
+        raise ManifestError(
+            f"manifest entry {index} category must be one of {sorted(VALID_CATEGORIES)}"
+        )
+    if category != RUN_CATEGORY and not reason:
+        raise ManifestError(f"manifest entry {index} must include a skip reason")
+    return category, reason
+
+
+def _parse_manifest_entry(entry: dict, index: int, root: Path) -> Tutorial:
+    if not isinstance(entry, dict):
+        raise ManifestError(f"manifest entry {index} must be an object")
+
+    rel_path = _entry_path(entry, index)
+    category, reason = _entry_category(entry, index)
+    notebook_path = root / rel_path
+    if not notebook_path.is_file():
+        raise ManifestError(f"notebook does not exist: {rel_path}")
+
+    return Tutorial(path=notebook_path, category=category, reason=reason)
+
+
+def load_manifest(manifest_path: Path, root: Path) -> list[Tutorial]:
+    try:
+        raw = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ManifestError(f"{manifest_path} is not valid JSON: {exc}") from exc
+
+    entries = raw.get("notebooks")
+    if not isinstance(entries, list) or not entries:
+        raise ManifestError("manifest must contain a non-empty 'notebooks' list")
+
+    return [
+        _parse_manifest_entry(entry, index, root)
+        for index, entry in enumerate(entries, start=1)
+    ]
+
+
+def build_nbconvert_command(
+    notebook_path: Path,
+    output_dir: Path,
+    timeout: int,
+    python_executable: str = sys.executable,
+) -> list[str]:
+    return [
+        python_executable,
+        "-m",
+        "jupyter",
+        "nbconvert",
+        "--to",
+        "notebook",
+        "--execute",
+        str(notebook_path),
+        "--output",
+        notebook_path.name,
+        "--output-dir",
+        str(output_dir),
+        f"--ExecutePreprocessor.timeout={timeout}",
+    ]
+
+
+def _env_with_src_path(root: Path) -> dict[str, str]:
+    env = os.environ.copy()
+    src_path = str(root / "src")
+    existing = env.get("PYTHONPATH")
+    env["PYTHONPATH"] = f"{src_path}{os.pathsep}{existing}" if existing else src_path
+    return env
+
+
+def run_tutorials(
+    tutorials: list[Tutorial],
+    root: Path,
+    output_dir: Path,
+    timeout: int,
+    dry_run: bool = False,
+) -> int:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    env = _env_with_src_path(root)
+
+    for tutorial in tutorials:
+        rel_path = tutorial.path.relative_to(root)
+        if tutorial.category != RUN_CATEGORY:
+            print(f"SKIP {rel_path} ({tutorial.category}): {tutorial.reason}", flush=True)
+            continue
+
+        tutorial_output_dir = output_dir / rel_path.parent
+        tutorial_output_dir.mkdir(parents=True, exist_ok=True)
+        command = build_nbconvert_command(tutorial.path, tutorial_output_dir, timeout)
+
+        print(f"EXECUTE {rel_path}", flush=True)
+        if dry_run:
+            print(f"DRY-RUN {shlex.join(command)}", flush=True)
+            continue
+
+        result = subprocess.run(command, cwd=root, env=env, check=False)
+        if result.returncode != 0:
+            print(f"FAILED {rel_path} with exit code {result.returncode}", file=sys.stderr)
+            return result.returncode
+
+    print(f"Executed notebooks written to {output_dir}", flush=True)
+    return 0
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    root = repository_root()
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--manifest",
+        type=Path,
+        default=root / "examples" / "tutorials.json",
+        help="Path to the tutorial notebook manifest.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=root / "executed-notebooks",
+        help="Directory where executed notebooks are written.",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=int,
+        default=600,
+        help="Per-notebook execution timeout in seconds.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Validate and list notebook commands without executing them.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    root = repository_root()
+    args = parse_args(argv)
+    try:
+        tutorials = load_manifest(args.manifest, root)
+    except ManifestError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+
+    return run_tutorials(
+        tutorials=tutorials,
+        root=root,
+        output_dir=args.output_dir,
+        timeout=args.timeout,
+        dry_run=args.dry_run,
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify_tutorials.py
+++ b/scripts/verify_tutorials.py
@@ -153,6 +153,7 @@ def run_tutorials(
     timeout: int,
     dry_run: bool = False,
 ) -> int:
+    output_dir = output_dir.resolve()
     output_dir.mkdir(parents=True, exist_ok=True)
     env = _env_with_src_path(root)
 

--- a/tests/test_verify_tutorials.py
+++ b/tests/test_verify_tutorials.py
@@ -129,3 +129,35 @@ def test_run_tutorials_returns_nbconvert_failure(tmp_path, monkeypatch):
     )
 
     assert exit_code == 11
+
+
+def test_run_tutorials_executes_copied_workspace(tmp_path, monkeypatch):
+    run_notebook = make_notebook(tmp_path, "examples/demo/demo.ipynb")
+    source_data = tmp_path / "examples" / "demo" / "input.txt"
+    source_data.write_text("source data", encoding="utf-8")
+    output_dir = tmp_path / "executed"
+    tutorials = [verify_tutorials.Tutorial(run_notebook, "self_contained")]
+    calls = []
+
+    def record_nbconvert(command, **kwargs):
+        calls.append((command, kwargs))
+        cwd = Path(kwargs["cwd"])
+        (cwd / "side-effect.txt").write_text("generated", encoding="utf-8")
+        return subprocess.CompletedProcess(args=command, returncode=0)
+
+    monkeypatch.setattr(verify_tutorials.subprocess, "run", record_nbconvert)
+
+    exit_code = verify_tutorials.run_tutorials(
+        tutorials=tutorials,
+        root=tmp_path,
+        output_dir=output_dir,
+        timeout=30,
+    )
+
+    workspace = output_dir / "examples" / "demo"
+    assert exit_code == 0
+    assert calls[0][0][7] == str(workspace / "demo.ipynb")
+    assert calls[0][1]["cwd"] == workspace
+    assert (workspace / "input.txt").read_text(encoding="utf-8") == "source data"
+    assert (workspace / "side-effect.txt").is_file()
+    assert not (tmp_path / "examples" / "demo" / "side-effect.txt").exists()

--- a/tests/test_verify_tutorials.py
+++ b/tests/test_verify_tutorials.py
@@ -132,10 +132,11 @@ def test_run_tutorials_returns_nbconvert_failure(tmp_path, monkeypatch):
 
 
 def test_run_tutorials_executes_copied_workspace(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
     run_notebook = make_notebook(tmp_path, "examples/demo/demo.ipynb")
     source_data = tmp_path / "examples" / "demo" / "input.txt"
     source_data.write_text("source data", encoding="utf-8")
-    output_dir = tmp_path / "executed"
+    output_dir = Path("executed")
     tutorials = [verify_tutorials.Tutorial(run_notebook, "self_contained")]
     calls = []
 
@@ -154,7 +155,7 @@ def test_run_tutorials_executes_copied_workspace(tmp_path, monkeypatch):
         timeout=30,
     )
 
-    workspace = output_dir / "examples" / "demo"
+    workspace = tmp_path / "executed" / "examples" / "demo"
     assert exit_code == 0
     assert calls[0][0][7] == str(workspace / "demo.ipynb")
     assert calls[0][1]["cwd"] == workspace

--- a/tests/test_verify_tutorials.py
+++ b/tests/test_verify_tutorials.py
@@ -1,0 +1,131 @@
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+SCRIPT_PATH = Path(__file__).resolve().parents[1] / "scripts" / "verify_tutorials.py"
+SPEC = importlib.util.spec_from_file_location("verify_tutorials", SCRIPT_PATH)
+verify_tutorials = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = verify_tutorials
+SPEC.loader.exec_module(verify_tutorials)
+
+
+def write_manifest(path, entries):
+    path.write_text(json.dumps({"notebooks": entries}), encoding="utf-8")
+
+
+def make_notebook(root, rel_path):
+    notebook = root / rel_path
+    notebook.parent.mkdir(parents=True, exist_ok=True)
+    notebook.write_text("{}", encoding="utf-8")
+    return notebook
+
+
+def test_load_manifest_classifies_runnable_and_skipped_notebooks(tmp_path):
+    make_notebook(tmp_path, "examples/run.ipynb")
+    make_notebook(tmp_path, "examples/external.ipynb")
+    manifest = tmp_path / "tutorials.json"
+    write_manifest(
+        manifest,
+        [
+            {"path": "examples/run.ipynb", "category": "self_contained"},
+            {
+                "path": "examples/external.ipynb",
+                "category": "external",
+                "reason": "Requires external data",
+            },
+        ],
+    )
+
+    tutorials = verify_tutorials.load_manifest(manifest, tmp_path)
+
+    assert [tutorial.category for tutorial in tutorials] == ["self_contained", "external"]
+    assert tutorials[1].reason == "Requires external data"
+
+
+def test_load_manifest_requires_skip_reason(tmp_path):
+    make_notebook(tmp_path, "examples/external.ipynb")
+    manifest = tmp_path / "tutorials.json"
+    write_manifest(
+        manifest,
+        [{"path": "examples/external.ipynb", "category": "external"}],
+    )
+
+    try:
+        verify_tutorials.load_manifest(manifest, tmp_path)
+    except verify_tutorials.ManifestError as exc:
+        assert "skip reason" in str(exc)
+    else:
+        raise AssertionError("external notebooks without skip reasons should fail")
+
+
+def test_build_nbconvert_command_writes_to_output_directory(tmp_path):
+    notebook = make_notebook(tmp_path, "examples/demo/demo.ipynb")
+    output_dir = tmp_path / "executed" / "examples" / "demo"
+
+    command = verify_tutorials.build_nbconvert_command(
+        notebook_path=notebook,
+        output_dir=output_dir,
+        timeout=120,
+        python_executable="python",
+    )
+
+    assert command == [
+        "python",
+        "-m",
+        "jupyter",
+        "nbconvert",
+        "--to",
+        "notebook",
+        "--execute",
+        str(notebook),
+        "--output",
+        "demo.ipynb",
+        "--output-dir",
+        str(output_dir),
+        "--ExecutePreprocessor.timeout=120",
+    ]
+
+
+def test_run_tutorials_dry_run_reports_skips_and_commands(tmp_path, capsys):
+    run_notebook = make_notebook(tmp_path, "examples/run.ipynb")
+    external_notebook = make_notebook(tmp_path, "examples/external.ipynb")
+    tutorials = [
+        verify_tutorials.Tutorial(run_notebook, "self_contained"),
+        verify_tutorials.Tutorial(external_notebook, "external", "Requires external code"),
+    ]
+
+    exit_code = verify_tutorials.run_tutorials(
+        tutorials=tutorials,
+        root=tmp_path,
+        output_dir=tmp_path / "executed",
+        timeout=30,
+        dry_run=True,
+    )
+
+    output = capsys.readouterr().out
+    assert exit_code == 0
+    assert "EXECUTE examples/run.ipynb" in output
+    assert "DRY-RUN" in output
+    assert "SKIP examples/external.ipynb (external): Requires external code" in output
+
+
+def test_run_tutorials_returns_nbconvert_failure(tmp_path, monkeypatch):
+    run_notebook = make_notebook(tmp_path, "examples/run.ipynb")
+    tutorials = [verify_tutorials.Tutorial(run_notebook, "self_contained")]
+
+    def fail_nbconvert(*args, **kwargs):
+        return subprocess.CompletedProcess(args=args[0], returncode=11)
+
+    monkeypatch.setattr(verify_tutorials.subprocess, "run", fail_nbconvert)
+
+    exit_code = verify_tutorials.run_tutorials(
+        tutorials=tutorials,
+        root=tmp_path,
+        output_dir=tmp_path / "executed",
+        timeout=30,
+    )
+
+    assert exit_code == 11


### PR DESCRIPTION
## Summary

- Adds `examples/tutorials.json` to classify tutorial notebooks for CI, including visible skip reasons for the external QEDC conversion notebook and Wishart notebooks that exceed the lightweight CI timeout.
- Adds `scripts/verify_tutorials.py` so local developers and CI can execute the runnable notebooks into a predictable output directory.
- Adds a Python 3.10 `tutorial-smoke` GitHub Actions job that installs example/notebook dependencies, executes the manifest, and uploads executed notebooks as artifacts.
- Documents the local tutorial smoke command and covers the verifier with focused tests.

## Tests run

- `conda run -n stochastic-benchmark-ci-py310 python scripts/verify_tutorials.py --output-dir /tmp/stochastic-benchmark-executed-notebooks-py310` - passed; executed 4 notebooks, skipped both Wishart notebooks as slow, and skipped `examples/QEDC_to_WS_conversion/conversion.ipynb` with the issue #54 reason.
- `conda run -n stochastic-benchmark-ci-py310 python -m pytest tests/test_verify_tutorials.py -v` - passed, 5 tests.
- `conda run -n stochastic-benchmark-ci-py310 python -m pytest tests/ -v` - passed, 248 tests, 1 warning.
- `conda run -n stochastic-benchmark-ci-py310 flake8 scripts/verify_tutorials.py tests/test_verify_tutorials.py --count --max-complexity=10 --max-line-length=120 --statistics` - passed.
- `conda run -n stochastic-benchmark-ci-py310 flake8 src --count --select=E9,F63,F7,F82 --show-source --statistics` - passed with count 0.
- `conda run -n stochastic-benchmark-ci-py310 flake8 src --count --exit-zero --max-complexity=10 --max-line-length=120 --statistics` - completed with exit 0; reported existing warning-only style findings in `src/`.
- `git diff --check` and `git diff --cached --check` - passed.

## Notes

- I used the existing local `stochastic-benchmark-ci-py310` environment to match the single Python 3.10 tutorial job. A Python 3.13 base-environment attempt was not used for validation because it pulled pandas 3.0 and exposed unrelated `tqdm`/pandas compatibility failures outside the issue's requested one-version scope.
- CI showed that both Wishart notebooks time out in GitHub Actions after 600 seconds, so they are classified as `slow` and skipped with visible reasons. The smoke job still executes the other self-contained tutorials.

Closes #56
