### PR TITLE
Remove exp_raw dependency for reruns

### DIFF
--- a/src/stochastic_benchmark.py
+++ b/src/stochastic_benchmark.py
@@ -280,18 +280,10 @@ class stochastic_benchmark:
 
         logger.info("Loading and bootstrapping experimental data...")
         if self.reduce_mem:
-            found_bs_results = self._bootstrap_checkpoint_files()
-            if len(found_bs_results) >= 1 and self.recover:
-                logger.info(
-                    "Found %s bootstrapped results files in checkpoints: reading results.",
-                    len(found_bs_results),
-                )
-                self.bs_results = found_bs_results
-                return
-
             self.raw_data = glob.glob(os.path.join(self.here.raw_data, "*.pkl"))
 
             if len(self.raw_data) == 0:
+                found_bs_results = self._bootstrap_checkpoint_files()
                 if len(found_bs_results) >= 1:
                     logger.info(
                         "Found %s bootstrapped results files and no raw data: reading results.",
@@ -322,7 +314,6 @@ class stochastic_benchmark:
 
                 if (
                     all([os.path.exists(bs_name) for bs_name in bs_names])
-                    and len(bs_names) > 1
                     and self.recover
                 ):
                     logger.info(

--- a/src/stochastic_benchmark.py
+++ b/src/stochastic_benchmark.py
@@ -280,12 +280,18 @@ class stochastic_benchmark:
 
         logger.info("Loading and bootstrapping experimental data...")
         if self.reduce_mem:
+            found_bs_results = self._bootstrap_checkpoint_files()
+            if len(found_bs_results) >= 1 and self.recover:
+                logger.info(
+                    "Found %s bootstrapped results files in checkpoints: reading results.",
+                    len(found_bs_results),
+                )
+                self.bs_results = found_bs_results
+                return
+
             self.raw_data = glob.glob(os.path.join(self.here.raw_data, "*.pkl"))
 
             if len(self.raw_data) == 0:
-                found_bs_results = glob.glob(
-                    os.path.join(self.here.checkpoints, "bootstrapped_results*.pkl")
-                )
                 if len(found_bs_results) >= 1:
                     logger.info(
                         "Found %s bootstrapped results files and no raw data: reading results.",
@@ -370,6 +376,24 @@ class stochastic_benchmark:
             )
             if isinstance(self.bs_results, pd.DataFrame):
                 self.bs_results.to_pickle(self.here.bootstrap)
+
+    def _bootstrap_checkpoint_files(self):
+        """
+        Return reusable bootstrapped result pickle files from checkpoints.
+
+        Reduced-memory runs write one file per group. If those files are present,
+        they should be used instead of deriving expected checkpoint names from
+        exp_raw. A single aggregate bootstrap file can also be reused by the
+        interpolation path as a one-item list.
+        """
+        segmented_results = sorted(
+            glob.glob(os.path.join(self.here.checkpoints, "bootstrapped_results_*.pkl"))
+        )
+        if len(segmented_results) >= 1:
+            return segmented_results
+        if os.path.exists(self.here.bootstrap):
+            return [self.here.bootstrap]
+        return []
 
     def set_Bootstrap(self, bs_results):
         """

--- a/tests/test_stochastic_benchmark.py
+++ b/tests/test_stochastic_benchmark.py
@@ -1,0 +1,43 @@
+import os
+
+import pandas as pd
+import pytest
+
+import stochastic_benchmark as sb_module
+
+
+def test_reduce_mem_bootstrap_prefers_checkpoint_pickles_over_stale_exp_raw(
+    tmp_path, monkeypatch
+):
+    """Existing bootstrap pickles should make reruns independent of exp_raw."""
+    sb = sb_module.stochastic_benchmark(
+        parameter_names=["param"],
+        here=tmp_path,
+        instance_cols=["instance"],
+        reduce_mem=True,
+        recover=True,
+    )
+
+    raw_dir = tmp_path / "exp_raw"
+    raw_dir.mkdir()
+    (raw_dir / "raw_results_inst=stale.pkl").write_text("not a pickle")
+
+    checkpoint_path = (
+        tmp_path / "checkpoints" / "bootstrapped_results_inst=1.pkl"
+    )
+    pd.DataFrame({"param": [1], "instance": [1], "resource": [1]}).to_pickle(
+        checkpoint_path
+    )
+
+    def fail_bootstrap_from_raw(*args, **kwargs):
+        pytest.fail(
+            "run_Bootstrap should not use exp_raw when checkpoint pickles exist"
+        )
+
+    monkeypatch.setattr(
+        sb_module.bootstrap, "Bootstrap_reduce_mem", fail_bootstrap_from_raw
+    )
+
+    sb.run_Bootstrap(bsParams_iter=object(), group_name_fcn=lambda _: "missing")
+
+    assert sb.bs_results == [os.fspath(checkpoint_path)]

--- a/tests/test_stochastic_benchmark.py
+++ b/tests/test_stochastic_benchmark.py
@@ -28,6 +28,40 @@ def test_reduce_mem_bootstrap_recovers_checkpoint_pickles_without_exp_raw(
     assert sb.bs_results == [str(checkpoint_path)]
 
 
+def test_reduce_mem_bootstrap_recovers_aggregate_checkpoint_without_exp_raw(tmp_path):
+    """Aggregate bootstrap pickles can be recovered when raw files are absent."""
+    sb = sb_module.stochastic_benchmark(
+        parameter_names=["param"],
+        here=tmp_path,
+        instance_cols=["instance"],
+        reduce_mem=True,
+        recover=True,
+    )
+
+    bootstrap_path = tmp_path / "checkpoints" / "bootstrapped_results.pkl"
+    pd.DataFrame({"param": [1], "instance": [1], "resource": [1]}).to_pickle(
+        bootstrap_path
+    )
+
+    sb.run_Bootstrap(bsParams_iter=object())
+
+    assert sb.bs_results == [str(bootstrap_path)]
+
+
+def test_reduce_mem_bootstrap_errors_without_raw_or_checkpoints(tmp_path):
+    """Reduced-memory bootstrapping still reports missing inputs clearly."""
+    sb = sb_module.stochastic_benchmark(
+        parameter_names=["param"],
+        here=tmp_path,
+        instance_cols=["instance"],
+        reduce_mem=True,
+        recover=True,
+    )
+
+    with pytest.raises(Exception, match="No raw data found"):
+        sb.run_Bootstrap(bsParams_iter=object())
+
+
 def test_reduce_mem_bootstrap_recovers_expected_checkpoint_pickles_with_exp_raw(
     tmp_path, monkeypatch
 ):
@@ -61,6 +95,24 @@ def test_reduce_mem_bootstrap_recovers_expected_checkpoint_pickles_with_exp_raw(
     sb.run_Bootstrap(bsParams_iter=object(), group_name_fcn=lambda _: "inst=1")
 
     assert sb.bs_results == [str(checkpoint_path)]
+
+
+def test_reduce_mem_bootstrap_requires_group_name_fcn_with_exp_raw(tmp_path):
+    """Raw-file reduced-memory runs need group names for checkpoint recovery."""
+    sb = sb_module.stochastic_benchmark(
+        parameter_names=["param"],
+        here=tmp_path,
+        instance_cols=["instance"],
+        reduce_mem=True,
+        recover=True,
+    )
+
+    raw_dir = tmp_path / "exp_raw"
+    raw_dir.mkdir()
+    (raw_dir / "raw_results_inst=1.pkl").write_text("not a pickle")
+
+    with pytest.raises(Exception, match="group_name_fcn should be provided"):
+        sb.run_Bootstrap(bsParams_iter=object())
 
 
 def test_reduce_mem_bootstrap_does_not_recover_partial_checkpoint_set(

--- a/tests/test_stochastic_benchmark.py
+++ b/tests/test_stochastic_benchmark.py
@@ -1,13 +1,11 @@
-import os
-
 import pandas as pd
 import pytest
 
 import stochastic_benchmark as sb_module
 
 
-def test_reduce_mem_bootstrap_prefers_checkpoint_pickles_over_stale_exp_raw(
-    tmp_path, monkeypatch
+def test_reduce_mem_bootstrap_recovers_checkpoint_pickles_without_exp_raw(
+    tmp_path,
 ):
     """Existing bootstrap pickles should make reruns independent of exp_raw."""
     sb = sb_module.stochastic_benchmark(
@@ -18,13 +16,35 @@ def test_reduce_mem_bootstrap_prefers_checkpoint_pickles_over_stale_exp_raw(
         recover=True,
     )
 
-    raw_dir = tmp_path / "exp_raw"
-    raw_dir.mkdir()
-    (raw_dir / "raw_results_inst=stale.pkl").write_text("not a pickle")
-
     checkpoint_path = (
         tmp_path / "checkpoints" / "bootstrapped_results_inst=1.pkl"
     )
+    pd.DataFrame({"param": [1], "instance": [1], "resource": [1]}).to_pickle(
+        checkpoint_path
+    )
+
+    sb.run_Bootstrap(bsParams_iter=object())
+
+    assert sb.bs_results == [str(checkpoint_path)]
+
+
+def test_reduce_mem_bootstrap_recovers_expected_checkpoint_pickles_with_exp_raw(
+    tmp_path, monkeypatch
+):
+    """Raw inputs should only recover the matching complete checkpoint set."""
+    sb = sb_module.stochastic_benchmark(
+        parameter_names=["param"],
+        here=tmp_path,
+        instance_cols=["instance"],
+        reduce_mem=True,
+        recover=True,
+    )
+
+    raw_dir = tmp_path / "exp_raw"
+    raw_dir.mkdir()
+    (raw_dir / "raw_results_inst=1.pkl").write_text("not a pickle")
+
+    checkpoint_path = tmp_path / "checkpoints" / "bootstrapped_results_inst=1.pkl"
     pd.DataFrame({"param": [1], "instance": [1], "resource": [1]}).to_pickle(
         checkpoint_path
     )
@@ -38,6 +58,50 @@ def test_reduce_mem_bootstrap_prefers_checkpoint_pickles_over_stale_exp_raw(
         sb_module.bootstrap, "Bootstrap_reduce_mem", fail_bootstrap_from_raw
     )
 
-    sb.run_Bootstrap(bsParams_iter=object(), group_name_fcn=lambda _: "missing")
+    sb.run_Bootstrap(bsParams_iter=object(), group_name_fcn=lambda _: "inst=1")
 
-    assert sb.bs_results == [os.fspath(checkpoint_path)]
+    assert sb.bs_results == [str(checkpoint_path)]
+
+
+def test_reduce_mem_bootstrap_does_not_recover_partial_checkpoint_set(
+    tmp_path, monkeypatch
+):
+    """Partial checkpoints should not silently drop raw-data groups."""
+    sb = sb_module.stochastic_benchmark(
+        parameter_names=["param"],
+        here=tmp_path,
+        instance_cols=["instance"],
+        reduce_mem=True,
+        recover=True,
+    )
+
+    raw_dir = tmp_path / "exp_raw"
+    raw_dir.mkdir()
+    raw_files = [
+        raw_dir / "raw_results_inst=1.pkl",
+        raw_dir / "raw_results_inst=2.pkl",
+    ]
+    for raw_file in raw_files:
+        raw_file.write_text("not a pickle")
+
+    checkpoint_path = tmp_path / "checkpoints" / "bootstrapped_results_inst=1.pkl"
+    pd.DataFrame({"param": [1], "instance": [1], "resource": [1]}).to_pickle(
+        checkpoint_path
+    )
+
+    expected_results = ["rebuilt-results"]
+
+    def bootstrap_from_raw(raw_data, *args, **kwargs):
+        assert sorted(raw_data) == sorted(str(raw_file) for raw_file in raw_files)
+        return expected_results
+
+    monkeypatch.setattr(sb_module.bootstrap, "Bootstrap_reduce_mem", bootstrap_from_raw)
+
+    def group_name(raw_filename):
+        if raw_filename.endswith("inst=1.pkl"):
+            return "inst=1"
+        return "inst=2"
+
+    sb.run_Bootstrap(bsParams_iter=object(), group_name_fcn=group_name)
+
+    assert sb.bs_results == expected_results


### PR DESCRIPTION
## Summary

- Make reduced-memory bootstrap reruns prefer existing `checkpoints/bootstrapped_results_*.pkl` files before inspecting `exp_raw/`.
- Keep the existing fallback that reuses bootstrap pickles when raw data is missing.
- Add a regression test proving stale `exp_raw/` contents do not force re-bootstrapping when checkpoint pickles already exist.

## Tests run

- `python -m pytest tests/test_stochastic_benchmark.py -v` - passed, 1 test.
- `python -m pytest tests/test_stochastic_benchmark.py tests/test_smoke.py::TestStochasticBenchmarkErrorHandling -v` - passed, 4 tests.
- `python -m pytest tests/test_experiments.py::TestStochasticBenchmarkRuntimeErrors -v` - passed, 3 tests.
- `python -m flake8 src --count --select=E9,F63,F7,F82 --show-source --statistics` - passed, output `0`.
- `python run_tests.py unit --fast` - failed in the local Python 3.13.5 / pandas 3.0.1 environment with 237 passed and 2 failed. Both failures are in `tests/test_interpolate.py` where `tqdm.progress_apply` imports a pandas private symbol that is absent in pandas 3.0.1; this path is unrelated to the changed bootstrap recovery code.

## Notes

- Full coverage and tutorial smoke commands were not run locally.

Closes #36
