### PR TITLE
Add progress_apply fallback for pandas/tqdm compatibility

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,30 @@
+# Agent Notes
+
+This file captures repository-specific workflow notes for future coding agents.
+
+## GitHub CLI
+
+- Use `gh` for GitHub operations in this repository when requested.
+- Avoid `gh issue view <issue> --comments`; some GitHub CLI versions request deprecated GraphQL fields. Prefer:
+  ```bash
+  gh issue view <issue> --json number,title,body,state,author,labels,assignees,comments,url
+  ```
+- If `gh pr view --web=false` fails on deprecated `projectCards` GraphQL fields, inspect explicit fields instead:
+  ```bash
+  gh pr view <pr> --json number,title,url,state,headRefName,baseRefName,author,commits,body
+  ```
+- GitHub does not allow a PR author to approve their own PR. If reviewing a PR authored by the current authenticated account, submit findings as `COMMENT` unless another review state is allowed.
+
+## Tests And Coverage
+
+- Documented test entry points are in `README.md`, `TESTING.md`, `run_tests.py`, and `.github/workflows/ci.yml`.
+- Useful local checks:
+  ```bash
+  python run_tests.py unit
+  python run_tests.py coverage
+  flake8 src --count --select=E9,F63,F7,F82 --show-source --statistics
+  flake8 src --count --exit-zero --max-complexity=10 --max-line-length=120 --statistics
+  ```
+- The second flake8 command is advisory because it uses `--exit-zero`; it may print existing style warnings while still exiting successfully.
+- The docs mention an 80% project-wide coverage target, but the current repository baseline is below that and CI does not enforce `coverage fail_under`. Treat passing patch coverage and passing `coverage-summary` as satisfying current enforced PR checks, while tracking the project-wide gap separately.
+- The current project-wide coverage gap is tracked in https://github.com/usra-riacs/stochastic-benchmark/issues/69.

--- a/src/bootstrap.py
+++ b/src/bootstrap.py
@@ -307,11 +307,9 @@ def Bootstrap(df, group_on, bs_params_list, progress_dir=None):
                 temp_df = pd.read_pickle(filename)
                 return temp_df
 
-        temp_df = (
-            df.groupby(group_on)
-            .progress_apply(lambda df: BootstrapSingle(df, bs_params))
-            .reset_index()
-        )
+        temp_df = df_utils.progress_apply_or_apply(
+            df.groupby(group_on), lambda df: BootstrapSingle(df, bs_params)
+        ).reset_index()
         temp_df.drop("level_{}".format(len(group_on)), axis=1, inplace=True)
         temp_df["boots"] = bs_params.downsample
         return temp_df
@@ -371,11 +369,10 @@ def Bootstrap_reduce_mem(df, group_on, bs_params_list, bootstrap_dir, name_fcn=N
                     return BootstrapSingle(lower_group_df[1], bs_params)
 
                 def bs_params_eval(bs_params):
-                    temp_df = (
-                        df_group.groupby(group_on)
-                        .progress_apply(lambda df: BootstrapSingle(df, bs_params))
-                        .reset_index()
-                    )
+                    temp_df = df_utils.progress_apply_or_apply(
+                        df_group.groupby(group_on),
+                        lambda df: BootstrapSingle(df, bs_params),
+                    ).reset_index()
                     temp_df.drop("level_{}".format(len(group_on)), axis=1, inplace=True)
                     temp_df["boots"] = bs_params.downsample
                     return temp_df
@@ -412,11 +409,10 @@ def Bootstrap_reduce_mem(df, group_on, bs_params_list, bootstrap_dir, name_fcn=N
                         return BootstrapSingle(lower_group_df[1], bs_params)
 
                     def bs_params_eval(bs_params):
-                        temp_df = (
-                            df_group.groupby(group_on)
-                            .progress_apply(lambda df: BootstrapSingle(df, bs_params))
-                            .reset_index()
-                        )
+                        temp_df = df_utils.progress_apply_or_apply(
+                            df_group.groupby(group_on),
+                            lambda df: BootstrapSingle(df, bs_params),
+                        ).reset_index()
                         temp_df.drop(
                             "level_{}".format(len(group_on)), axis=1, inplace=True
                         )
@@ -451,11 +447,10 @@ def Bootstrap_reduce_mem(df, group_on, bs_params_list, bootstrap_dir, name_fcn=N
                         return BootstrapSingle(lower_group_df[1], bs_params)
 
                     def bs_params_eval(bs_params):
-                        temp_df = (
-                            df_group.groupby(group_on)
-                            .progress_apply(lambda df: BootstrapSingle(df, bs_params))
-                            .reset_index()
-                        )
+                        temp_df = df_utils.progress_apply_or_apply(
+                            df_group.groupby(group_on),
+                            lambda df: BootstrapSingle(df, bs_params),
+                        ).reset_index()
                         temp_df.drop(
                             "level_{}".format(len(group_on)), axis=1, inplace=True
                         )

--- a/src/cross_validation.py
+++ b/src/cross_validation.py
@@ -5,6 +5,7 @@ import os
 import stats
 import interpolate
 import utils_ws
+import df_utils
 import warnings
 
 parameters_dict = dict()
@@ -267,8 +268,10 @@ def interpolate_raw_performance(
     )
 
     # For each split_ind, do interpolation separately over the resource grid
-    temp_df_interp = df_many_splits_performance_raw.groupby(group_on).progress_apply(
-        lambda df: interpolate.InterpolateSingle(df, iParams, group_on), include_groups=False
+    temp_df_interp = df_utils.progress_apply_or_apply(
+        df_many_splits_performance_raw.groupby(group_on),
+        lambda df: interpolate.InterpolateSingle(df, iParams, group_on),
+        include_groups=False,
     )
     temp_df_interp.reset_index(inplace=True)
     return temp_df_interp

--- a/src/df_utils.py
+++ b/src/df_utils.py
@@ -36,6 +36,22 @@ def applyParallel(dfGrouped, func):
     return pd.concat(ret_list)
 
 
+def progress_apply_or_apply(grouped, func, **kwargs):
+    """
+    Apply a function to a pandas groupby object with a tqdm/pandas fallback.
+
+    Some pandas/tqdm combinations raise an AttributeError for the internal
+    ``_is_builtin_func`` lookup when using progress_apply. In that compatibility
+    case, fall back to pandas apply while preserving the same arguments.
+    """
+    try:
+        return grouped.progress_apply(func, **kwargs)
+    except AttributeError as exc:
+        if "_is_builtin_func" not in str(exc):
+            raise
+        return grouped.apply(func, **kwargs)
+
+
 def monotone_df(
     df, resource_col, response_col, opt_sense, extrapolate_from=None, match_on=None
 ):

--- a/src/interpolate.py
+++ b/src/interpolate.py
@@ -5,6 +5,7 @@ import warnings
 from tqdm import tqdm
 from typing import Callable
 import itertools
+import df_utils
 from utils_ws import *
 
 tqdm.pandas()
@@ -162,7 +163,9 @@ def Interpolate(df: pd.DataFrame, interp_params: InterpolationParameters, group_
     def dfInterp(df):
         return InterpolateSingle(df, interp_params, group_on)
 
-    df_interp = df.groupby(group_on).progress_apply(dfInterp, include_groups=False)
+    df_interp = df_utils.progress_apply_or_apply(
+        df.groupby(group_on), dfInterp, include_groups=False
+    )
     return df_interp
 
 
@@ -190,9 +193,10 @@ def Interpolate_reduce_mem(
     for df_name in df_list:
         df = pd.read_pickle(df_name)
         generateResourceColumn(df, interp_params)
-        temp_df_interp = df.groupby(group_on).progress_apply(
+        temp_df_interp = df_utils.progress_apply_or_apply(
+            df.groupby(group_on),
             lambda df: InterpolateSingle(df, interp_params, group_on),
-            include_groups=False
+            include_groups=False,
         )
         temp_df_interp.reset_index(inplace=True)
         df_interp_list.append(temp_df_interp)

--- a/src/stats.py
+++ b/src/stats.py
@@ -8,6 +8,7 @@ from tqdm import tqdm
 from typing import List, Tuple, Union, DefaultDict
 import warnings
 
+import df_utils
 import names
 
 EPSILON = 1e-10
@@ -561,13 +562,9 @@ def Stats(
     def dfSS(df):
         return StatsSingle(df, stats_params, drop_singletons=drop_singletons)
 
-    grouped = df.groupby(group_on)
-    try:
-        df_stats = grouped.progress_apply(dfSS, include_groups=False).reset_index()
-    except AttributeError as exc:
-        if "_is_builtin_func" not in str(exc):
-            raise
-        df_stats = grouped.apply(dfSS, include_groups=False).reset_index()
+    df_stats = df_utils.progress_apply_or_apply(
+        df.groupby(group_on), dfSS, include_groups=False
+    ).reset_index()
 
     df_stats.drop("level_{}".format(len(group_on)), axis=1, inplace=True)
     applyBounds(df_stats, stats_params)

--- a/tests/test_df_utils.py
+++ b/tests/test_df_utils.py
@@ -14,6 +14,7 @@ sys.path.insert(0, SRC_PATH)
 
 from df_utils import (
     applyParallel,
+    progress_apply_or_apply,
     monotone_df,
     eval_cumm,
     read_exp_raw,
@@ -92,6 +93,71 @@ class TestApplyParallel:
         x_results = result[result.index == 0]  # First group result
         if len(x_results) > 0:
             assert x_results['count'].iloc[0] == 2
+
+
+class TestProgressApplyOrApply:
+    """Test class for progress_apply_or_apply compatibility helper."""
+
+    class DummyGrouped:
+        def __init__(self, progress_result=None, progress_exc=None):
+            self.progress_result = progress_result
+            self.progress_exc = progress_exc
+            self.progress_called = False
+            self.apply_called = False
+            self.progress_kwargs = None
+            self.apply_kwargs = None
+
+        def progress_apply(self, func, **kwargs):
+            self.progress_called = True
+            self.progress_kwargs = kwargs
+            if self.progress_exc is not None:
+                raise self.progress_exc
+            return self.progress_result
+
+        def apply(self, func, **kwargs):
+            self.apply_called = True
+            self.apply_kwargs = kwargs
+            return func("fallback-group")
+
+    def test_uses_progress_apply_when_available(self):
+        """progress_apply result should be returned unchanged when it succeeds."""
+        grouped = self.DummyGrouped(progress_result="progress-result")
+
+        result = progress_apply_or_apply(
+            grouped, lambda df: "fallback-result", include_groups=False
+        )
+
+        assert result == "progress-result"
+        assert grouped.progress_called is True
+        assert grouped.apply_called is False
+        assert grouped.progress_kwargs == {"include_groups": False}
+
+    def test_falls_back_for_tqdm_builtin_func_attribute_error(self):
+        """Known pandas/tqdm _is_builtin_func AttributeError should use apply."""
+        grouped = self.DummyGrouped(
+            progress_exc=AttributeError(
+                "'DataFrameGroupBy' object has no attribute '_is_builtin_func'"
+            )
+        )
+
+        result = progress_apply_or_apply(
+            grouped, lambda df: f"handled {df}", include_groups=False
+        )
+
+        assert result == "handled fallback-group"
+        assert grouped.progress_called is True
+        assert grouped.apply_called is True
+        assert grouped.apply_kwargs == {"include_groups": False}
+
+    def test_reraises_other_attribute_errors(self):
+        """Unrelated AttributeErrors should not be hidden by the fallback."""
+        grouped = self.DummyGrouped(progress_exc=AttributeError("different failure"))
+
+        with pytest.raises(AttributeError, match="different failure"):
+            progress_apply_or_apply(grouped, lambda df: df)
+
+        assert grouped.progress_called is True
+        assert grouped.apply_called is False
 
 
 class TestMonotoneDf:


### PR DESCRIPTION
## Summary

- Added `df_utils.progress_apply_or_apply` to centralize the pandas/tqdm fallback for the `_is_builtin_func` `AttributeError`.
- Updated interpolation, bootstrap, cross-validation, and stats grouped apply paths to use the helper.
- Added focused helper tests covering successful `progress_apply`, compatibility fallback, and unrelated `AttributeError` re-raise behavior.

## Tests run

- `python -m pytest tests/test_df_utils.py::TestProgressApplyOrApply -v` - 3 passed
- `python -m pytest tests/test_interpolate.py::TestInterpolate::test_interpolate_basic tests/test_interpolate.py::TestInterpolateReduceMem::test_interpolate_reduce_mem_basic -v` - 2 passed
- `python run_tests.py unit` - 241 passed, 6 warnings
- `flake8 src --count --select=E9,F63,F7,F82 --show-source --statistics` - passed with output `0`
- `flake8 src --count --exit-zero --max-complexity=10 --max-line-length=120 --statistics` - completed with existing advisory style output and exit code 0
- `python run_tests.py coverage` - 252 passed, 6 warnings; coverage completed

## Notes

- Did not run the full local multi-version conda CI matrix or tutorial notebook smoke job; those are left to GitHub Actions.

Closes #67
