### PR TITLE
Clarify coverage policy and expand utils tests

### DIFF
--- a/.github/copilot-setup-steps.yml
+++ b/.github/copilot-setup-steps.yml
@@ -63,7 +63,7 @@ setup_steps:
     4_quality_checks:
       - "flake8 src --max-line-length=120"
       - "pytest tests/ -v"
-      - "Coverage should be >80% for new code"
+      - "Coverage should stay at or above 80% project-wide and cover new or changed behavior"
 
   common_patterns:
     testing_multiprocess:
@@ -196,7 +196,8 @@ setup_steps:
         - "Smoke tests for all modules"
       
       coverage_requirements:
-        minimum_coverage: "80%"
+        enforced_minimum_coverage: "80%"
+        pull_request_expectation: "new or changed behavior should be covered"
         report_format: "xml, html, term"
         upload_to: "codecov"
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -73,11 +73,21 @@ The repository includes automated testing via GitHub Actions:
 
 - **Matrix Testing**: Tests across Python versions 3.10, 3.11, 3.12
 - **Linting**: Code quality checks with flake8
-- **Coverage**: Automated coverage reporting via Codecov
+- **Coverage**: Automated coverage reporting via Codecov, including patch
+  coverage reporting for pull requests
 - **Integration Tests**: Cross-module functionality verification
 - **Tutorial Smoke Tests**: Self-contained notebooks execute on Python 3.10 and upload executed notebooks as artifacts
 
 ## Test Coverage
+
+### Coverage Policy
+
+CI enforces that the test suite completes, coverage reports are generated, and
+project-wide coverage stays at or above 80%. Codecov also reports patch coverage
+for pull requests.
+
+Contributors should keep new or changed behavior covered by focused tests and
+avoid reducing project-wide coverage.
 
 ### Current Coverage Status
 - ✅ **names.py** (103 lines) - Path management, parameter/filename conversion
@@ -120,7 +130,7 @@ When adding new functionality:
 2. Include edge cases and error conditions
 3. Update integration tests if the change affects module interactions
 4. Ensure tests pass locally before submitting PR
-5. Maintain test coverage above 80%
+5. Cover new or changed behavior and keep project-wide coverage at or above 80%
 
 ### Test Naming Convention
 - Test files: `test_<module_name>.py`

--- a/TESTING.md
+++ b/TESTING.md
@@ -96,11 +96,11 @@ avoid reducing project-wide coverage.
 - ✅ **success_metrics.py** (353 lines) - Success metric calculations (Response, PerfRatio, etc.)
 - ✅ **bootstrap.py** (441 lines) - Bootstrap sampling and statistical methods
 - ✅ **training.py** (328 lines) - Training algorithms and parameter optimization
+- ✅ **utils_ws.py** (534 lines) - Workspace utility interpolation and progress processing
 
 ### Modules Needing Tests
 - 🔄 **plotting.py** (611 lines) - Plotting and visualization
 - 🔄 **stochastic_benchmark.py** (1796 lines) - Main benchmark class
-- 🔄 **utils_ws.py** (533 lines) - Utility functions
 - 🔄 **cross_validation.py** (534 lines) - Cross-validation methods
 - 🔄 **sequential_exploration.py** (388 lines) - Sequential exploration strategies
 - 🔄 **random_exploration.py** (315 lines) - Random exploration methods

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ omit = [
 ]
 
 [tool.coverage.report]
+fail_under = 80
 exclude_lines = [
     "pragma: no cover",
     "def __repr__",

--- a/tests/test_utils_ws.py
+++ b/tests/test_utils_ws.py
@@ -1,11 +1,20 @@
-import pandas as pd
-import numpy as np
-import pytest
-import sys
 import os
+import sys
+
+import numpy as np
+import pandas as pd
+import pytest
+
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'src')))
 
-from utils_ws import gen_log_space, take_closest, interp, interpolate_df, process_df_progress
+from utils_ws import (
+    gen_log_space,
+    interp,
+    interpolate_df,
+    process_df_progress,
+    take_closest,
+)
+
 
 class TestGenLogSpace:
     def test_basic_generation(self):
@@ -15,6 +24,7 @@ class TestGenLogSpace:
         assert vals[-1] <= 100
         assert np.all(np.diff(vals) > 0)
 
+
 class TestTakeClosest:
     def test_various_cases(self):
         arr = [1, 3, 5, 7]
@@ -22,6 +32,7 @@ class TestTakeClosest:
         assert take_closest(arr, 3) == 3
         assert take_closest(arr, 0) == 1
         assert take_closest(arr, 10) == 7
+
 
 class TestInterp:
     def test_numeric_and_object_columns(self):
@@ -35,9 +46,13 @@ class TestInterp:
 
 
 class TestInterpolateDf:
-    def test_none_and_empty_inputs_return_none(self):
-        assert interpolate_df(dataframe=None, parameters_dict={}, results_path="/tmp") is None
-        assert interpolate_df(dataframe=pd.DataFrame(), parameters_dict={}, results_path="/tmp") is None
+    def test_none_and_empty_inputs_return_none(self, tmp_path):
+        assert interpolate_df(dataframe=None, parameters_dict={}, results_path=tmp_path) is None
+        assert interpolate_df(
+            dataframe=pd.DataFrame(),
+            parameters_dict={},
+            results_path=tmp_path,
+        ) is None
 
     def test_derived_resource_multiple_instances_and_partial_recovery(self, tmp_path):
         df = pd.DataFrame({
@@ -53,7 +68,7 @@ class TestInterpolateDf:
             resource_column="reads",
             prefix="run.pkl",
             parameters_dict={"sweep": [2], "replica": [1]},
-            results_path=str(tmp_path),
+            results_path=tmp_path,
             resource_values=[2, 4],
         )
 
@@ -73,7 +88,7 @@ class TestInterpolateDf:
             resource_column="reads",
             prefix="run.pkl",
             parameters_dict={"sweep": [2], "replica": [1]},
-            results_path=str(tmp_path),
+            results_path=tmp_path,
             resource_values=[2, 4],
             overwrite_pickles=False,
         )
@@ -83,6 +98,69 @@ class TestInterpolateDf:
             recovered.sort_index(axis=1),
             check_dtype=False,
         )
+
+    def test_interpolates_resource_from_boots_and_parameters(self, tmp_path):
+        df = pd.DataFrame({
+            'sweep': [1, 1, 1, 2, 2, 2],
+            'replica': [1, 1, 1, 1, 1, 1],
+            'boots': [1, 2, 4, 1, 2, 4],
+            'score': [10.0, 20.0, 40.0, 20.0, 40.0, 80.0],
+            'instance': ['i1', 'i1', 'i1', 'i1', 'i1', 'i1'],
+        })
+
+        result = interpolate_df(
+            dataframe=df,
+            parameters_dict={'sweep': [1, 2], 'replica': [1]},
+            resource_values=[1, 2, 4, 8],
+            prefix='results.pkl',
+            results_path=tmp_path,
+            save_pickle=True,
+        )
+
+        assert set(result['sweep']) == {1, 2}
+        assert set(result['replica']) == {1}
+        assert set(result['instance']) == {'i1'}
+
+        sweep_one = result[result['sweep'] == 1].sort_values('reads')
+        np.testing.assert_array_equal(sweep_one['reads'].to_numpy(), [1, 2, 4])
+        np.testing.assert_array_equal(sweep_one['boots'].to_numpy(), [1, 2, 4])
+        np.testing.assert_array_equal(sweep_one['score'].to_numpy(), [10.0, 20.0, 40.0])
+
+        sweep_two = result[result['sweep'] == 2].sort_values('reads')
+        np.testing.assert_array_equal(sweep_two['reads'].to_numpy(), [2, 4, 8])
+        np.testing.assert_array_equal(sweep_two['boots'].to_numpy(), [1, 2, 4])
+        np.testing.assert_array_equal(sweep_two['score'].to_numpy(), [20.0, 40.0, 80.0])
+
+        assert (tmp_path / 'results_interp.pkl').exists()
+        assert (tmp_path / 'resultsi1_partial.pkl').exists()
+
+    def test_reads_existing_partial_when_overwrite_disabled(self, tmp_path):
+        cached = pd.DataFrame({
+            'reads': [3],
+            'boots': [3],
+            'sweep': [1],
+            'replica': [1],
+            'score': [30.0],
+        })
+        cached.to_pickle(tmp_path / 'cached0_partial.pkl')
+        df = pd.DataFrame({
+            'sweep': [1, 1],
+            'replica': [1, 1],
+            'boots': [1, 2],
+            'score': [10.0, 20.0],
+        })
+
+        result = interpolate_df(
+            dataframe=df,
+            parameters_dict={'sweep': [1], 'replica': [1]},
+            resource_values=[1, 2],
+            prefix='cached.pkl',
+            results_path=tmp_path,
+            overwrite_pickles=False,
+            save_pickle=False,
+        )
+
+        pd.testing.assert_frame_equal(result.reset_index(drop=True), cached)
 
     def test_all_datapoints_interpolates_inside_resource_grid(self, tmp_path):
         df = pd.DataFrame({
@@ -98,7 +176,7 @@ class TestInterpolateDf:
             resource_column="reads",
             prefix="all.pkl",
             parameters_dict={"sweep": [2], "replica": [1]},
-            results_path=str(tmp_path),
+            results_path=tmp_path,
             resource_values=[2, 3, 4],
             all_datapoints=True,
             save_pickle=False,
@@ -110,6 +188,9 @@ class TestInterpolateDf:
 
 
 class TestProcessDfProgress:
+    def test_returns_none_for_missing_dataframe(self, tmp_path):
+        assert process_df_progress(df_progress=None, results_path=tmp_path) is None
+
     def test_progress_best_and_end_frames_are_computed_and_saved(self, tmp_path):
         df = pd.DataFrame({
             "R_budget": [10, 10, 20],
@@ -126,7 +207,7 @@ class TestProcessDfProgress:
             stat_measures=["mean"],
             maximizing=True,
             df_progress_name="progress.pkl",
-            results_path=str(tmp_path),
+            results_path=tmp_path,
         )
 
         assert (tmp_path / "progress_end.pkl").exists()
@@ -153,7 +234,7 @@ class TestProcessDfProgress:
             stat_measures=["mean"],
             maximizing=False,
             df_progress_name="progress.pkl",
-            results_path=str(tmp_path),
+            results_path=tmp_path,
             use_raw_dataframes=False,
             save_pickle=False,
         )
@@ -162,3 +243,26 @@ class TestProcessDfProgress:
         row = best.set_index("R_budget").loc[10]
         assert row["mean_inv_perf_ratio"] == pytest.approx(0.2)
         assert row["mean_perf_ratio"] == pytest.approx(0.8)
+
+    def test_processes_inverse_metric_for_minimization(self, tmp_path):
+        df = pd.DataFrame({
+            'R_budget': [10, 10, 20, 20],
+            'R_explor': [2, 2, 5, 5],
+            'tau': [1, 1, 1, 1],
+            'cum_reads': [5, 10, 10, 20],
+            'inv_perf_ratio': [0.8, 0.3, 0.6, 0.1],
+        })
+
+        best, end = process_df_progress(
+            df_progress=df,
+            compute_metrics=['inv_perf_ratio'],
+            stat_measures=['mean'],
+            maximizing=False,
+            df_progress_name='inverse.pkl',
+            results_path=tmp_path,
+            save_pickle=False,
+        )
+
+        assert 'perf_ratio' in df.columns
+        assert 'mean_perf_ratio' in best.columns
+        assert set(end['f_explor']) == {0.2, 0.25}


### PR DESCRIPTION
## Summary

- Enforced the documented 80% project-wide coverage policy with `coverage report` `fail_under = 80`.
- Updated testing documentation and Copilot setup metadata so CI behavior and coverage expectations match.
- Added focused tests for `utils_ws.py`, covering `interpolate_df` and `process_df_progress` paths. Targeted `utils_ws.py` coverage is now 91%.

## Tests run

- `python -m pytest tests/test_utils_ws.py -v` - 12 passed
- `python -m pytest tests/test_utils_ws.py --cov=utils_ws --cov-report=term-missing -v` - 12 passed; `src/utils_ws.py` coverage reported at 91%, and the 80% threshold was reached
- `flake8 src --count --select=E9,F63,F7,F82 --show-source --statistics` - passed with output `0`
- `flake8 src --count --exit-zero --max-complexity=10 --max-line-length=120 --statistics` - completed with existing advisory style output and exit code 0
- `git diff --check` - passed
- `python run_tests.py coverage` - 306 passed, 2 failed; failures are the known Python 3.13 pandas/tqdm `progress_apply` compatibility issue from #67 on current `main`, not from this PR. The generated coverage report showed total coverage at 86%, above the new 80% threshold.

## Notes

- Local `python` is 3.13.5. `python3.12` is present but does not have `pytest` installed, and `python3.10`/`python3.11` are not installed locally. The GitHub Actions matrix covers Python 3.10, 3.11, and 3.12.

Closes #69
