### PR TITLE
Validate Noori repeat reliability formulas

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ Use the root README as the entry point, then follow the focused documents for th
 - [examples/general_workflow.md](examples/general_workflow.md) for the end-to-end benchmark flow
 - [CI-TESTING.md](CI-TESTING.md) for local CI reproduction and environment setup
 - [TESTING.md](TESTING.md) for the test suite overview
+- [docs/noori_repeat_reliability_validation.md](docs/noori_repeat_reliability_validation.md) for validation of Noori et al. repeat-reliability formulas
 - [examples/wishart_n_50_alpha_0.5/README.md](examples/wishart_n_50_alpha_0.5/README.md) for the Wishart example details
 
 ## Testing

--- a/docs/noori_repeat_reliability_validation.md
+++ b/docs/noori_repeat_reliability_validation.md
@@ -5,6 +5,10 @@ formulas without an author reference implementation, executable code, or raw
 numerical data. The formulas are implemented as deterministic reference helpers
 in `src/repeat_reliability.py`; downstream production integrations should cite
 the same equation labels and reuse these tests when behavior is changed.
+The API uses `confidence_fraction` for statistical confidence-interval coverage
+and `target_confidence` for the `R_c` target probability, so callers do not
+confuse these fractional values with the percentage-style `confidence_level`
+arguments used elsewhere in the repository.
 
 Paper reference:
 
@@ -56,8 +60,13 @@ figures.
 ## Boundary Policy
 
 The implementation clips Agresti-Coull probability intervals to `[0, 1]`, as
-discussed in the paper for boundary cases. `R_c(0)` is infinite and `R_c(p)` is
+discussed in the paper for boundary cases. `target_confidence` is validated as
+an open probability interval, `0 < c < 1`. `R_c(0)` is infinite and `R_c(p)` is
 clamped to `1` when `p >= c`, matching Eq. (1)'s `max(..., 1)` form.
+
+Deterministic RTT/CETS scaling accepts zero scale for finite repeat counts. It
+rejects zero scale for non-finite repeat counts because `0 * infinity` is
+undefined and would otherwise produce `nan` bounds.
 
 The paper source text contains an apparent mismatch around the `epsilon_p = 0.03`
 repeat-count example. Eq. (10) with a two-sided 95 percent normal critical value

--- a/docs/noori_repeat_reliability_validation.md
+++ b/docs/noori_repeat_reliability_validation.md
@@ -1,0 +1,65 @@
+# Noori et al. Repeat-Reliability Validation
+
+This note defines how this repository validates the Noori et al. repeat-reliability
+formulas without an author reference implementation, executable code, or raw
+numerical data. The formulas are implemented as deterministic reference helpers
+in `src/repeat_reliability.py`; downstream production integrations should cite
+the same equation labels and reuse these tests when behavior is changed.
+
+Paper reference:
+
+Noori, Moslem, Elisabetta Valiante, Ignacio Rozada, Thomas Van Vaerenbergh, and
+Masoud Mohseni. "Statistical analysis for per-instance evaluation of stochastic
+optimizers: Avoiding unreliable conclusions." Physical Review Applied 25, no. 3
+(2026): 034081.
+
+## Equation Map
+
+| Paper item | Repository function | Validation coverage |
+| --- | --- | --- |
+| Eq. (8), Agresti-Coull confidence interval for success probability | `agresti_coull_interval`, `agresti_coull_interval_from_estimate` | Deterministic fixture grid in `tests/test_repeat_reliability.py` for `p_hat in {0, 0.01, 0.1, 0.5, 0.9, 0.99, 1}` and `n in {100, 1000, 10000}`. |
+| Eq. (9), confidence-interval width and relative width | `ProportionInterval.width`, `ProportionInterval.relative_width` | Covered by the same fixture grid because lower, upper, and adjusted estimate are asserted numerically. |
+| Eq. (10), worst-case repeats needed for an absolute success-probability error | `required_repeats_for_probability_error` | Exact numeric checks for error tolerances `0.01` and `0.03` at 95 percent confidence. |
+| Eqs. (1)-(2), `R_c` from success probability | `repeat_count` | Deterministic fixture grid checks the induced `R_c` point estimate from each Agresti-Coull estimate. |
+| Confidence interval of `R_c` induced by the success-probability interval | `repeat_count_interval` | Deterministic fixture grid checks lower and upper `R_c` bounds, including boundary cases with infinite upper bounds. |
+| Eq. (3), CETS scaling from `R_c` | `cets_from_repeat_count`, `scaled_repeat_count_interval` | Unit test verifies deterministic scaling preserves relative error. |
+| RTT/time-to-solution scaling from `R_c` | `rtt_from_repeat_count`, `scaled_repeat_count_interval` | Unit test verifies deterministic scaling preserves relative error. |
+| Eq. (13), maximum relative error in `R_c` | `maximum_relative_error` | Deterministic fixture grid checks exact relative-error values for finite intervals. |
+| Eq. (19), lower-bound repeats for target `R_c` relative error | `required_repeats_lower_bound` | Numeric checks and qualitative fixed-seed Bernoulli tests cover monotonic behavior for low vs. moderate success probabilities. |
+| Exact numerical repeats for target `R_c` relative error | `required_repeats_exact` | Binary-search numerical checks assert stable required-repeat values and compare them with lower-bound behavior. |
+
+## Validation Strategy
+
+The validation intentionally uses two classes of checks.
+
+Exact deterministic checks:
+
+- Use fixed `p_hat` and `n` fixture inputs.
+- Assert numerical Agresti-Coull estimates and intervals.
+- Assert induced `R_c` intervals and maximum relative errors.
+- Assert lower-bound and exact repeat-count outputs for selected parameters.
+- Do not compare against paper plots or author data that are not available.
+
+Qualitative fixed-seed Bernoulli checks:
+
+- Show that an `R_c` interval induced by a success-probability interval is
+  asymmetric.
+- Show that low estimated success probability requires more repeats than a
+  moderate estimated success probability under the Eq. (19) lower bound.
+- Show that noisy small-sample estimates can invert optimizer rankings even
+  when the first optimizer has the larger true success probability.
+
+These tests use fixed RNG seeds and only assert qualitative claims from the
+paper. They are not treated as reproduction of the paper's Monte Carlo tables or
+figures.
+
+## Boundary Policy
+
+The implementation clips Agresti-Coull probability intervals to `[0, 1]`, as
+discussed in the paper for boundary cases. `R_c(0)` is infinite and `R_c(p)` is
+clamped to `1` when `p >= c`, matching Eq. (1)'s `max(..., 1)` form.
+
+The paper source text contains an apparent mismatch around the `epsilon_p = 0.03`
+repeat-count example. Eq. (10) with a two-sided 95 percent normal critical value
+gives `n = 1064`, and one later sentence in the source also refers to `1064`;
+the tests follow the equation rather than the inconsistent prose value.

--- a/src/repeat_reliability.py
+++ b/src/repeat_reliability.py
@@ -40,18 +40,17 @@ class RepeatCountInterval:
     upper: float
 
 
-def normal_critical_value(confidence_level: float = 0.95) -> float:
+def normal_critical_value(confidence_fraction: float = 0.95) -> float:
     """Return z_alpha for a two-sided confidence interval."""
 
-    if not 0 < confidence_level < 1:
-        raise ValueError("confidence_level must be a fraction between 0 and 1")
-    return float(scipy_stats.norm.ppf(0.5 + confidence_level / 2.0))
+    _validate_open_probability(confidence_fraction, "confidence_fraction")
+    return float(scipy_stats.norm.ppf(0.5 + confidence_fraction / 2.0))
 
 
 def agresti_coull_interval(
     successes: float,
     repeats: int,
-    confidence_level: float = 0.95,
+    confidence_fraction: float = 0.95,
 ) -> ProportionInterval:
     """Compute the Agresti-Coull interval from paper Eq. (8).
 
@@ -65,7 +64,7 @@ def agresti_coull_interval(
     if successes < 0 or successes > repeats:
         raise ValueError("successes must be between 0 and repeats")
 
-    z = normal_critical_value(confidence_level)
+    z = normal_critical_value(confidence_fraction)
     adjusted_repeats = repeats + z**2
     estimate = (successes + z**2 / 2.0) / adjusted_repeats
     half_width = z * math.sqrt(estimate * (1.0 - estimate) / adjusted_repeats)
@@ -80,7 +79,7 @@ def agresti_coull_interval(
 def agresti_coull_interval_from_estimate(
     success_probability: float,
     repeats: int,
-    confidence_level: float = 0.95,
+    confidence_fraction: float = 0.95,
 ) -> ProportionInterval:
     """Compute Eq. (8) from an observed success fraction n_s / n."""
 
@@ -88,14 +87,14 @@ def agresti_coull_interval_from_estimate(
     return agresti_coull_interval(
         successes=success_probability * repeats,
         repeats=repeats,
-        confidence_level=confidence_level,
+        confidence_fraction=confidence_fraction,
     )
 
 
 def success_probability_margin(
     adjusted_success_probability: float,
     repeats: int,
-    confidence_level: float = 0.95,
+    confidence_fraction: float = 0.95,
 ) -> float:
     """Return epsilon_p from paper Eq. (11) for an adjusted p_hat."""
 
@@ -103,7 +102,7 @@ def success_probability_margin(
     if repeats <= 0:
         raise ValueError("repeats must be positive")
 
-    z = normal_critical_value(confidence_level)
+    z = normal_critical_value(confidence_fraction)
     adjusted_repeats = repeats + z**2
     return z * math.sqrt(
         adjusted_success_probability * (1.0 - adjusted_success_probability)
@@ -111,18 +110,18 @@ def success_probability_margin(
     )
 
 
-def repeat_count(success_probability: float, confidence: float = 0.99) -> float:
+def repeat_count(success_probability: float, target_confidence: float = 0.99) -> float:
     """Compute R_c from paper Eqs. (1) and (2)."""
 
     _validate_probability(success_probability, "success_probability")
-    _validate_probability(confidence, "confidence")
+    _validate_open_probability(target_confidence, "target_confidence")
 
     if success_probability == 0:
         return math.inf
-    if success_probability >= confidence:
+    if success_probability >= target_confidence:
         return 1.0
     return max(
-        math.log1p(-confidence) / math.log1p(-success_probability),
+        math.log1p(-target_confidence) / math.log1p(-success_probability),
         1.0,
     )
 
@@ -130,7 +129,7 @@ def repeat_count(success_probability: float, confidence: float = 0.99) -> float:
 def repeat_count_interval(
     success_probability_lower: float,
     success_probability_upper: float,
-    confidence: float = 0.99,
+    target_confidence: float = 0.99,
 ) -> RepeatCountInterval:
     """Induce an R_c interval from a probability interval.
 
@@ -141,12 +140,13 @@ def repeat_count_interval(
 
     _validate_probability(success_probability_lower, "success_probability_lower")
     _validate_probability(success_probability_upper, "success_probability_upper")
+    _validate_open_probability(target_confidence, "target_confidence")
     if success_probability_lower > success_probability_upper:
         raise ValueError("success_probability_lower must be <= success_probability_upper")
 
     return RepeatCountInterval(
-        lower=repeat_count(success_probability_upper, confidence=confidence),
-        upper=repeat_count(success_probability_lower, confidence=confidence),
+        lower=repeat_count(success_probability_upper, target_confidence=target_confidence),
+        upper=repeat_count(success_probability_lower, target_confidence=target_confidence),
     )
 
 
@@ -161,7 +161,10 @@ def cets_from_repeat_count(
         raise ValueError("iterations must be non-negative")
     if effort_per_iteration < 0:
         raise ValueError("effort_per_iteration must be non-negative")
-    return iterations * effort_per_iteration * repeats_to_confidence
+    return _scale_repeat_count_value(
+        repeats_to_confidence,
+        iterations * effort_per_iteration,
+    )
 
 
 def rtt_from_repeat_count(
@@ -172,7 +175,7 @@ def rtt_from_repeat_count(
 
     if runtime_per_repeat < 0:
         raise ValueError("runtime_per_repeat must be non-negative")
-    return runtime_per_repeat * repeats_to_confidence
+    return _scale_repeat_count_value(repeats_to_confidence, runtime_per_repeat)
 
 
 def scaled_repeat_count_interval(
@@ -183,7 +186,10 @@ def scaled_repeat_count_interval(
 
     if scale < 0:
         raise ValueError("scale must be non-negative")
-    return RepeatCountInterval(lower=scale * interval.lower, upper=scale * interval.upper)
+    return RepeatCountInterval(
+        lower=_scale_repeat_count_value(interval.lower, scale),
+        upper=_scale_repeat_count_value(interval.upper, scale),
+    )
 
 
 def maximum_relative_error(
@@ -202,7 +208,7 @@ def maximum_relative_error(
 
 def required_repeats_for_probability_error(
     error_tolerance: float,
-    confidence_level: float = 0.95,
+    confidence_fraction: float = 0.95,
     min_repeats: int = 1,
 ) -> int:
     """Return the worst-case n bound from paper Eq. (10)."""
@@ -212,7 +218,7 @@ def required_repeats_for_probability_error(
     if min_repeats < 0:
         raise ValueError("min_repeats must be non-negative")
 
-    z = normal_critical_value(confidence_level)
+    z = normal_critical_value(confidence_fraction)
     bound = (z / (2.0 * error_tolerance)) ** 2 - z**2
     return max(min_repeats, math.ceil(bound))
 
@@ -220,7 +226,7 @@ def required_repeats_for_probability_error(
 def required_repeats_lower_bound(
     adjusted_success_probability: float,
     relative_error_threshold: float,
-    confidence_level: float = 0.95,
+    confidence_fraction: float = 0.95,
     min_repeats: int = 1,
 ) -> float:
     """Return the conservative lower-bound repeat count from paper Eq. (19)."""
@@ -233,7 +239,7 @@ def required_repeats_lower_bound(
     if adjusted_success_probability == 0:
         return math.inf
 
-    z = normal_critical_value(confidence_level)
+    z = normal_critical_value(confidence_fraction)
     threshold_factor = z * (1.0 + relative_error_threshold) / relative_error_threshold
     bound = (
         threshold_factor**2
@@ -247,8 +253,8 @@ def required_repeats_lower_bound(
 def required_repeats_exact(
     adjusted_success_probability: float,
     relative_error_threshold: float,
-    confidence: float = 0.99,
-    confidence_level: float = 0.95,
+    target_confidence: float = 0.99,
+    confidence_fraction: float = 0.95,
     min_repeats: int = 1,
     max_repeats: int = 100_000_000,
 ) -> float:
@@ -262,7 +268,7 @@ def required_repeats_exact(
 
     _validate_probability(adjusted_success_probability, "adjusted_success_probability")
     _validate_relative_error_threshold(relative_error_threshold)
-    _validate_probability(confidence, "confidence")
+    _validate_open_probability(target_confidence, "target_confidence")
     if min_repeats <= 0:
         raise ValueError("min_repeats must be positive")
     if max_repeats < min_repeats:
@@ -270,15 +276,15 @@ def required_repeats_exact(
     if adjusted_success_probability == 0:
         return math.inf
 
-    estimate = repeat_count(adjusted_success_probability, confidence=confidence)
+    estimate = repeat_count(adjusted_success_probability, target_confidence=target_confidence)
 
     if _repeat_count_error_satisfies_threshold(
         adjusted_success_probability,
         estimate,
         min_repeats,
         relative_error_threshold,
-        confidence,
-        confidence_level,
+        target_confidence,
+        confidence_fraction,
     ):
         return min_repeats
 
@@ -291,8 +297,8 @@ def required_repeats_exact(
             estimate,
             high,
             relative_error_threshold,
-            confidence,
-            confidence_level,
+            target_confidence,
+            confidence_fraction,
         ):
             break
         low = high + 1
@@ -306,8 +312,8 @@ def required_repeats_exact(
             estimate,
             midpoint,
             relative_error_threshold,
-            confidence,
-            confidence_level,
+            target_confidence,
+            confidence_fraction,
         ):
             high = midpoint
         else:
@@ -320,28 +326,39 @@ def _repeat_count_error_satisfies_threshold(
     repeat_estimate: float,
     repeats: int,
     relative_error_threshold: float,
-    confidence: float,
-    confidence_level: float,
+    target_confidence: float,
+    confidence_fraction: float,
 ) -> bool:
     margin = success_probability_margin(
         adjusted_success_probability,
         repeats,
-        confidence_level=confidence_level,
+        confidence_fraction=confidence_fraction,
     )
     lower_probability = max(0.0, adjusted_success_probability - margin)
     upper_probability = min(1.0, adjusted_success_probability + margin)
     interval = repeat_count_interval(
         lower_probability,
         upper_probability,
-        confidence=confidence,
+        target_confidence=target_confidence,
     )
     error = maximum_relative_error(repeat_estimate, interval.lower, interval.upper)
     return error <= relative_error_threshold
 
 
+def _scale_repeat_count_value(repeats_to_confidence: float, scale: float) -> float:
+    if scale == 0 and not math.isfinite(repeats_to_confidence):
+        raise ValueError("zero scale is undefined for non-finite repeat counts")
+    return scale * repeats_to_confidence
+
+
 def _validate_probability(value: float, name: str) -> None:
     if not 0 <= value <= 1:
         raise ValueError(f"{name} must be between 0 and 1")
+
+
+def _validate_open_probability(value: float, name: str) -> None:
+    if not 0 < value < 1:
+        raise ValueError(f"{name} must be between 0 and 1, exclusive")
 
 
 def _validate_relative_error_threshold(value: float) -> None:

--- a/src/repeat_reliability.py
+++ b/src/repeat_reliability.py
@@ -1,0 +1,359 @@
+"""Reference formulas for repeat-reliability validation.
+
+The functions in this module are small, deterministic implementations of the
+equations from Noori et al., "A Statistical Analysis for Per-Instance
+Evaluation of Stochastic Optimizers: Avoiding Unreliable Conclusions."
+They are intended as reviewable references for tests and later integrations.
+"""
+
+from dataclasses import dataclass
+import math
+
+from scipy import stats as scipy_stats
+
+
+@dataclass(frozen=True)
+class ProportionInterval:
+    """Agresti-Coull interval for a binomial success probability."""
+
+    estimate: float
+    lower: float
+    upper: float
+    half_width: float
+
+    @property
+    def width(self) -> float:
+        return self.upper - self.lower
+
+    @property
+    def relative_width(self) -> float:
+        if self.estimate == 0:
+            return math.inf
+        return self.width / self.estimate
+
+
+@dataclass(frozen=True)
+class RepeatCountInterval:
+    """Confidence interval induced on R_c by a probability interval."""
+
+    lower: float
+    upper: float
+
+
+def normal_critical_value(confidence_level: float = 0.95) -> float:
+    """Return z_alpha for a two-sided confidence interval."""
+
+    if not 0 < confidence_level < 1:
+        raise ValueError("confidence_level must be a fraction between 0 and 1")
+    return float(scipy_stats.norm.ppf(0.5 + confidence_level / 2.0))
+
+
+def agresti_coull_interval(
+    successes: float,
+    repeats: int,
+    confidence_level: float = 0.95,
+) -> ProportionInterval:
+    """Compute the Agresti-Coull interval from paper Eq. (8).
+
+    Eq. (8) defines n_hat = n + z_alpha^2, n_s_hat = n_s + z_alpha^2 / 2,
+    p_hat = n_s_hat / n_hat, and the interval
+    p_hat +/- z_alpha * sqrt(p_hat * (1 - p_hat) / n_hat).
+    """
+
+    if repeats <= 0:
+        raise ValueError("repeats must be positive")
+    if successes < 0 or successes > repeats:
+        raise ValueError("successes must be between 0 and repeats")
+
+    z = normal_critical_value(confidence_level)
+    adjusted_repeats = repeats + z**2
+    estimate = (successes + z**2 / 2.0) / adjusted_repeats
+    half_width = z * math.sqrt(estimate * (1.0 - estimate) / adjusted_repeats)
+    return ProportionInterval(
+        estimate=estimate,
+        lower=max(0.0, estimate - half_width),
+        upper=min(1.0, estimate + half_width),
+        half_width=half_width,
+    )
+
+
+def agresti_coull_interval_from_estimate(
+    success_probability: float,
+    repeats: int,
+    confidence_level: float = 0.95,
+) -> ProportionInterval:
+    """Compute Eq. (8) from an observed success fraction n_s / n."""
+
+    _validate_probability(success_probability, "success_probability")
+    return agresti_coull_interval(
+        successes=success_probability * repeats,
+        repeats=repeats,
+        confidence_level=confidence_level,
+    )
+
+
+def success_probability_margin(
+    adjusted_success_probability: float,
+    repeats: int,
+    confidence_level: float = 0.95,
+) -> float:
+    """Return epsilon_p from paper Eq. (11) for an adjusted p_hat."""
+
+    _validate_probability(adjusted_success_probability, "adjusted_success_probability")
+    if repeats <= 0:
+        raise ValueError("repeats must be positive")
+
+    z = normal_critical_value(confidence_level)
+    adjusted_repeats = repeats + z**2
+    return z * math.sqrt(
+        adjusted_success_probability * (1.0 - adjusted_success_probability)
+        / adjusted_repeats
+    )
+
+
+def repeat_count(success_probability: float, confidence: float = 0.99) -> float:
+    """Compute R_c from paper Eqs. (1) and (2)."""
+
+    _validate_probability(success_probability, "success_probability")
+    _validate_probability(confidence, "confidence")
+
+    if success_probability == 0:
+        return math.inf
+    if success_probability >= confidence:
+        return 1.0
+    return max(
+        math.log1p(-confidence) / math.log1p(-success_probability),
+        1.0,
+    )
+
+
+def repeat_count_interval(
+    success_probability_lower: float,
+    success_probability_upper: float,
+    confidence: float = 0.99,
+) -> RepeatCountInterval:
+    """Induce an R_c interval from a probability interval.
+
+    This implements the monotonic transformation described in the confidence
+    interval section: R_c^- uses the upper probability bound and R_c^+ uses the
+    lower probability bound.
+    """
+
+    _validate_probability(success_probability_lower, "success_probability_lower")
+    _validate_probability(success_probability_upper, "success_probability_upper")
+    if success_probability_lower > success_probability_upper:
+        raise ValueError("success_probability_lower must be <= success_probability_upper")
+
+    return RepeatCountInterval(
+        lower=repeat_count(success_probability_upper, confidence=confidence),
+        upper=repeat_count(success_probability_lower, confidence=confidence),
+    )
+
+
+def cets_from_repeat_count(
+    repeats_to_confidence: float,
+    iterations: float,
+    effort_per_iteration: float = 1.0,
+) -> float:
+    """Scale R_c to CETS from paper Eq. (3)."""
+
+    if iterations < 0:
+        raise ValueError("iterations must be non-negative")
+    if effort_per_iteration < 0:
+        raise ValueError("effort_per_iteration must be non-negative")
+    return iterations * effort_per_iteration * repeats_to_confidence
+
+
+def rtt_from_repeat_count(
+    repeats_to_confidence: float,
+    runtime_per_repeat: float = 1.0,
+) -> float:
+    """Scale R_c to runtime-to-target/time-to-solution."""
+
+    if runtime_per_repeat < 0:
+        raise ValueError("runtime_per_repeat must be non-negative")
+    return runtime_per_repeat * repeats_to_confidence
+
+
+def scaled_repeat_count_interval(
+    interval: RepeatCountInterval,
+    scale: float,
+) -> RepeatCountInterval:
+    """Apply deterministic RTT/CETS scaling to an R_c interval."""
+
+    if scale < 0:
+        raise ValueError("scale must be non-negative")
+    return RepeatCountInterval(lower=scale * interval.lower, upper=scale * interval.upper)
+
+
+def maximum_relative_error(
+    estimate: float,
+    lower: float,
+    upper: float,
+) -> float:
+    """Compute the maximum relative R_c error from paper Eq. (13)."""
+
+    if estimate <= 0 or not math.isfinite(estimate):
+        return math.inf
+    if not math.isfinite(lower) or not math.isfinite(upper):
+        return math.inf
+    return max(estimate - lower, upper - estimate, 0.0) / estimate
+
+
+def required_repeats_for_probability_error(
+    error_tolerance: float,
+    confidence_level: float = 0.95,
+    min_repeats: int = 1,
+) -> int:
+    """Return the worst-case n bound from paper Eq. (10)."""
+
+    if error_tolerance <= 0:
+        raise ValueError("error_tolerance must be positive")
+    if min_repeats < 0:
+        raise ValueError("min_repeats must be non-negative")
+
+    z = normal_critical_value(confidence_level)
+    bound = (z / (2.0 * error_tolerance)) ** 2 - z**2
+    return max(min_repeats, math.ceil(bound))
+
+
+def required_repeats_lower_bound(
+    adjusted_success_probability: float,
+    relative_error_threshold: float,
+    confidence_level: float = 0.95,
+    min_repeats: int = 1,
+) -> float:
+    """Return the conservative lower-bound repeat count from paper Eq. (19)."""
+
+    _validate_probability(adjusted_success_probability, "adjusted_success_probability")
+    _validate_relative_error_threshold(relative_error_threshold)
+    if min_repeats < 0:
+        raise ValueError("min_repeats must be non-negative")
+
+    if adjusted_success_probability == 0:
+        return math.inf
+
+    z = normal_critical_value(confidence_level)
+    threshold_factor = z * (1.0 + relative_error_threshold) / relative_error_threshold
+    bound = (
+        threshold_factor**2
+        * (1.0 - adjusted_success_probability)
+        / adjusted_success_probability
+        - z**2
+    )
+    return max(min_repeats, math.ceil(bound))
+
+
+def required_repeats_exact(
+    adjusted_success_probability: float,
+    relative_error_threshold: float,
+    confidence: float = 0.99,
+    confidence_level: float = 0.95,
+    min_repeats: int = 1,
+    max_repeats: int = 100_000_000,
+) -> float:
+    """Find the smallest n whose induced R_c error satisfies Eq. (14).
+
+    This is the exact numerical counterpart to the Eq. (19) lower bound. It
+    keeps p_hat fixed, uses Eq. (11) to compute epsilon_p(n), clips the induced
+    probability interval to [0, 1], and searches for the first n where the
+    induced Eq. (13) relative error is within the requested threshold.
+    """
+
+    _validate_probability(adjusted_success_probability, "adjusted_success_probability")
+    _validate_relative_error_threshold(relative_error_threshold)
+    _validate_probability(confidence, "confidence")
+    if min_repeats <= 0:
+        raise ValueError("min_repeats must be positive")
+    if max_repeats < min_repeats:
+        raise ValueError("max_repeats must be >= min_repeats")
+    if adjusted_success_probability == 0:
+        return math.inf
+
+    estimate = repeat_count(adjusted_success_probability, confidence=confidence)
+
+    if _repeat_count_error_satisfies_threshold(
+        adjusted_success_probability,
+        estimate,
+        min_repeats,
+        relative_error_threshold,
+        confidence,
+        confidence_level,
+    ):
+        return min_repeats
+
+    low = min_repeats
+    high = min_repeats
+    while high < max_repeats:
+        high = min(high * 2, max_repeats)
+        if _repeat_count_error_satisfies_threshold(
+            adjusted_success_probability,
+            estimate,
+            high,
+            relative_error_threshold,
+            confidence,
+            confidence_level,
+        ):
+            break
+        low = high + 1
+    else:
+        return math.inf
+
+    if high == max_repeats and not _repeat_count_error_satisfies_threshold(
+        adjusted_success_probability,
+        estimate,
+        high,
+        relative_error_threshold,
+        confidence,
+        confidence_level,
+    ):
+        return math.inf
+
+    while low < high:
+        midpoint = (low + high) // 2
+        if _repeat_count_error_satisfies_threshold(
+            adjusted_success_probability,
+            estimate,
+            midpoint,
+            relative_error_threshold,
+            confidence,
+            confidence_level,
+        ):
+            high = midpoint
+        else:
+            low = midpoint + 1
+    return low
+
+
+def _repeat_count_error_satisfies_threshold(
+    adjusted_success_probability: float,
+    repeat_estimate: float,
+    repeats: int,
+    relative_error_threshold: float,
+    confidence: float,
+    confidence_level: float,
+) -> bool:
+    margin = success_probability_margin(
+        adjusted_success_probability,
+        repeats,
+        confidence_level=confidence_level,
+    )
+    lower_probability = max(0.0, adjusted_success_probability - margin)
+    upper_probability = min(1.0, adjusted_success_probability + margin)
+    interval = repeat_count_interval(
+        lower_probability,
+        upper_probability,
+        confidence=confidence,
+    )
+    error = maximum_relative_error(repeat_estimate, interval.lower, interval.upper)
+    return error <= relative_error_threshold
+
+
+def _validate_probability(value: float, name: str) -> None:
+    if not 0 <= value <= 1:
+        raise ValueError(f"{name} must be between 0 and 1")
+
+
+def _validate_relative_error_threshold(value: float) -> None:
+    if not 0 < value < 1:
+        raise ValueError("relative_error_threshold must be between 0 and 1")

--- a/src/repeat_reliability.py
+++ b/src/repeat_reliability.py
@@ -299,16 +299,6 @@ def required_repeats_exact(
     else:
         return math.inf
 
-    if high == max_repeats and not _repeat_count_error_satisfies_threshold(
-        adjusted_success_probability,
-        estimate,
-        high,
-        relative_error_threshold,
-        confidence,
-        confidence_level,
-    ):
-        return math.inf
-
     while low < high:
         midpoint = (low + high) // 2
         if _repeat_count_error_satisfies_threshold(

--- a/tests/test_repeat_reliability.py
+++ b/tests/test_repeat_reliability.py
@@ -87,8 +87,8 @@ def test_noori_reference_grid_matches_deterministic_fixtures(
 
 
 def test_rtt_and_cets_scaling_preserve_relative_error():
-    repeat_estimate = repeat_count(0.25, confidence=0.99)
-    repeat_interval = repeat_count_interval(0.22, 0.28, confidence=0.99)
+    repeat_estimate = repeat_count(0.25, target_confidence=0.99)
+    repeat_interval = repeat_count_interval(0.22, 0.28, target_confidence=0.99)
     repeat_error = maximum_relative_error(
         repeat_estimate,
         repeat_interval.lower,
@@ -140,15 +140,23 @@ def test_required_repeats_lower_bound_and_exact_search_are_deterministic():
         lambda: agresti_coull_interval(-1, 10),
         lambda: agresti_coull_interval_from_estimate(-0.1, 10),
         lambda: success_probability_margin(0.5, 0),
+        lambda: repeat_count(0.5, target_confidence=0.0),
+        lambda: repeat_count(0.5, target_confidence=1.0),
         lambda: repeat_count_interval(0.8, 0.2),
+        lambda: repeat_count_interval(0.1, 0.2, target_confidence=0.0),
         lambda: cets_from_repeat_count(1.0, iterations=-1),
         lambda: cets_from_repeat_count(1.0, iterations=1, effort_per_iteration=-1),
+        lambda: cets_from_repeat_count(math.inf, iterations=0),
         lambda: rtt_from_repeat_count(1.0, runtime_per_repeat=-1),
+        lambda: rtt_from_repeat_count(math.inf, runtime_per_repeat=0),
         lambda: scaled_repeat_count_interval(RepeatCountInterval(1.0, 2.0), scale=-1),
+        lambda: scaled_repeat_count_interval(RepeatCountInterval(math.inf, math.inf), scale=0),
         lambda: required_repeats_for_probability_error(0.0),
         lambda: required_repeats_for_probability_error(0.1, min_repeats=-1),
         lambda: required_repeats_lower_bound(0.5, 0.1, min_repeats=-1),
         lambda: required_repeats_lower_bound(0.5, 1.0),
+        lambda: required_repeats_exact(0.5, 0.1, target_confidence=0.0),
+        lambda: required_repeats_exact(0.5, 0.1, target_confidence=1.0),
         lambda: required_repeats_exact(0.5, 0.1, min_repeats=0),
         lambda: required_repeats_exact(0.5, 0.1, min_repeats=10, max_repeats=1),
     ],

--- a/tests/test_repeat_reliability.py
+++ b/tests/test_repeat_reliability.py
@@ -4,10 +4,13 @@ import numpy as np
 import pytest
 
 from repeat_reliability import (
+    ProportionInterval,
+    RepeatCountInterval,
     agresti_coull_interval,
     agresti_coull_interval_from_estimate,
     cets_from_repeat_count,
     maximum_relative_error,
+    normal_critical_value,
     repeat_count,
     repeat_count_interval,
     required_repeats_exact,
@@ -15,6 +18,7 @@ from repeat_reliability import (
     required_repeats_lower_bound,
     rtt_from_repeat_count,
     scaled_repeat_count_interval,
+    success_probability_margin,
 )
 
 
@@ -103,6 +107,15 @@ def test_rtt_and_cets_scaling_preserve_relative_error():
     assert maximum_relative_error(cets_estimate, cets_interval.lower, cets_interval.upper) == pytest.approx(repeat_error)
 
 
+def test_interval_width_properties_cover_zero_estimate():
+    interval = ProportionInterval(estimate=0.25, lower=0.2, upper=0.3, half_width=0.05)
+    zero_estimate_interval = ProportionInterval(estimate=0.0, lower=0.0, upper=0.1, half_width=0.05)
+
+    assert interval.width == pytest.approx(0.1)
+    assert interval.relative_width == pytest.approx(0.4)
+    assert math.isinf(zero_estimate_interval.relative_width)
+
+
 def test_required_repeats_probability_error_bound_matches_paper_equation():
     assert required_repeats_for_probability_error(0.01) == 9600
     assert required_repeats_for_probability_error(0.03) == 1064
@@ -113,6 +126,41 @@ def test_required_repeats_lower_bound_and_exact_search_are_deterministic():
     assert required_repeats_exact(0.1, 0.1) == 4605
     assert required_repeats_exact(0.01, 0.1) > required_repeats_exact(0.1, 0.1)
     assert required_repeats_exact(0.1, 0.1) > required_repeats_exact(0.5, 0.1)
+    assert math.isinf(required_repeats_lower_bound(0.0, 0.1))
+    assert math.isinf(required_repeats_exact(0.0, 0.1))
+    assert math.isinf(required_repeats_exact(0.01, 0.001, max_repeats=2))
+    assert required_repeats_exact(1.0, 0.1) == 1
+
+
+@pytest.mark.parametrize(
+    "call",
+    [
+        lambda: normal_critical_value(1.0),
+        lambda: agresti_coull_interval(0, 0),
+        lambda: agresti_coull_interval(-1, 10),
+        lambda: agresti_coull_interval_from_estimate(-0.1, 10),
+        lambda: success_probability_margin(0.5, 0),
+        lambda: repeat_count_interval(0.8, 0.2),
+        lambda: cets_from_repeat_count(1.0, iterations=-1),
+        lambda: cets_from_repeat_count(1.0, iterations=1, effort_per_iteration=-1),
+        lambda: rtt_from_repeat_count(1.0, runtime_per_repeat=-1),
+        lambda: scaled_repeat_count_interval(RepeatCountInterval(1.0, 2.0), scale=-1),
+        lambda: required_repeats_for_probability_error(0.0),
+        lambda: required_repeats_for_probability_error(0.1, min_repeats=-1),
+        lambda: required_repeats_lower_bound(0.5, 0.1, min_repeats=-1),
+        lambda: required_repeats_lower_bound(0.5, 1.0),
+        lambda: required_repeats_exact(0.5, 0.1, min_repeats=0),
+        lambda: required_repeats_exact(0.5, 0.1, min_repeats=10, max_repeats=1),
+    ],
+)
+def test_validation_rejects_invalid_inputs(call):
+    with pytest.raises(ValueError):
+        call()
+
+
+def test_maximum_relative_error_rejects_nonfinite_estimates():
+    assert math.isinf(maximum_relative_error(0.0, 0.0, 1.0))
+    assert math.isinf(maximum_relative_error(1.0, 0.0, math.inf))
 
 
 def test_fixed_seed_bernoulli_rc_interval_is_asymmetric():

--- a/tests/test_repeat_reliability.py
+++ b/tests/test_repeat_reliability.py
@@ -1,0 +1,153 @@
+import math
+
+import numpy as np
+import pytest
+
+from repeat_reliability import (
+    agresti_coull_interval,
+    agresti_coull_interval_from_estimate,
+    cets_from_repeat_count,
+    maximum_relative_error,
+    repeat_count,
+    repeat_count_interval,
+    required_repeats_exact,
+    required_repeats_for_probability_error,
+    required_repeats_lower_bound,
+    rtt_from_repeat_count,
+    scaled_repeat_count_interval,
+)
+
+
+REFERENCE_GRID = [
+    (0.0, 100, 0.018496749103, 0.0, 0.044412051134, 246.662118617232, 101.371886661212, math.inf, math.inf),
+    (0.0, 1000, 0.001913379243, 0.0, 0.004616716146, 2404.522301848311, 995.194735863067, math.inf, math.inf),
+    (0.0, 10000, 0.000191999185, 0.0, 0.000463500969, 23983.06049718036, 9933.318713707136, math.inf, math.inf),
+    (0.01, 100, 0.028126814121, 0.0, 0.059926861882, 161.415289821065, 74.520210629335, math.inf, math.inf),
+    (0.01, 1000, 0.011875111658, 0.005174101181, 0.018576122135, 385.492989139588, 245.598267487361, 887.737969708359, 1.30286411094),
+    (0.01, 10000, 0.010188159202, 0.008220323323, 0.01215599508, 449.705481961264, 376.532146256283, 557.911893764758, 0.240616172459),
+    (0.1, 100, 0.114797399283, 0.053484752289, 0.176110046277, 37.766262448893, 23.772508663081, 83.778808093604, 1.218350524015),
+    (0.1, 1000, 0.101530703394, 0.082846876078, 0.12021453071, 43.013750285732, 35.956209885714, 53.25075866433, 0.237993858024),
+    (0.1, 10000, 0.100153599348, 0.094270825358, 0.106036373339, 43.637998557021, 41.084506657875, 46.509850931411, 0.06581081785),
+    (0.5, 100, 0.5, 0.403831530366, 0.596168469634, 6.643856189775, 5.078723061497, 8.903490739773, 0.340108889394),
+    (0.5, 1000, 0.5, 0.469069600368, 0.530930399632, 6.643856189775, 6.083414957563, 7.273721592451, 0.094804189718),
+    (0.5, 10000, 0.5, 0.490202061815, 0.509797938185, 6.643856189775, 6.459429512745, 6.835225017241, 0.028803878651),
+    (0.9, 100, 0.885202600717, 0.823889953723, 0.946515247711, 2.127505781374, 1.572611385934, 2.651760699727, 0.260819218588),
+    (0.9, 1000, 0.898469296606, 0.87978546929, 0.917153123922, 2.013282419249, 1.84890069314, 2.173811359636, 0.081648617471),
+    (0.9, 10000, 0.899846400652, 0.893963626661, 0.905729174642, 2.001334012617, 1.950034860166, 2.052239480047, 0.0256324792),
+    (0.99, 100, 0.971873185879, 0.940073138118, 1.0, 1.289590877697, 1.0, 1.636154480046, 0.268739185693),
+    (0.99, 1000, 0.988124888342, 0.981423877865, 0.994825898819, 1.038765536191, 1.0, 1.155371504963, 0.112254368006),
+    (0.99, 10000, 0.989811840798, 0.98784400492, 0.991779676677, 1.004064313122, 1.0, 1.044272188673, 0.040045119645),
+    (1.0, 100, 0.981503250897, 0.955587948866, 1.0, 1.154131627644, 1.0, 1.478743977145, 0.281261115913),
+    (1.0, 1000, 0.998086620757, 0.995383283854, 1.0, 1.0, 1.0, 1.0, 0.0),
+    (1.0, 10000, 0.999808000815, 0.999536499031, 1.0, 1.0, 1.0, 1.0, 0.0),
+]
+
+
+@pytest.mark.parametrize(
+    "p_hat,n,expected_p,expected_lower,expected_upper,"
+    "expected_r,expected_r_lower,expected_r_upper,expected_error",
+    REFERENCE_GRID,
+)
+def test_noori_reference_grid_matches_deterministic_fixtures(
+    p_hat,
+    n,
+    expected_p,
+    expected_lower,
+    expected_upper,
+    expected_r,
+    expected_r_lower,
+    expected_r_upper,
+    expected_error,
+):
+    interval = agresti_coull_interval_from_estimate(p_hat, n)
+    repeat_estimate = repeat_count(interval.estimate)
+    repeat_interval = repeat_count_interval(interval.lower, interval.upper)
+    max_error = maximum_relative_error(
+        repeat_estimate,
+        repeat_interval.lower,
+        repeat_interval.upper,
+    )
+
+    assert interval.estimate == pytest.approx(expected_p, abs=5e-13)
+    assert interval.lower == pytest.approx(expected_lower, abs=5e-13)
+    assert interval.upper == pytest.approx(expected_upper, abs=5e-13)
+    assert repeat_estimate == pytest.approx(expected_r, abs=5e-12)
+    assert repeat_interval.lower == pytest.approx(expected_r_lower, abs=5e-12)
+
+    if math.isinf(expected_r_upper):
+        assert math.isinf(repeat_interval.upper)
+        assert math.isinf(max_error)
+    else:
+        assert repeat_interval.upper == pytest.approx(expected_r_upper, abs=5e-12)
+        assert max_error == pytest.approx(expected_error, abs=5e-12)
+
+
+def test_rtt_and_cets_scaling_preserve_relative_error():
+    repeat_estimate = repeat_count(0.25, confidence=0.99)
+    repeat_interval = repeat_count_interval(0.22, 0.28, confidence=0.99)
+    repeat_error = maximum_relative_error(
+        repeat_estimate,
+        repeat_interval.lower,
+        repeat_interval.upper,
+    )
+
+    runtime_scale = 0.25
+    rtt_interval = scaled_repeat_count_interval(repeat_interval, runtime_scale)
+    rtt_estimate = rtt_from_repeat_count(repeat_estimate, runtime_scale)
+
+    cets_scale = 500 * 0.02
+    cets_interval = scaled_repeat_count_interval(repeat_interval, cets_scale)
+    cets_estimate = cets_from_repeat_count(repeat_estimate, iterations=500, effort_per_iteration=0.02)
+
+    assert maximum_relative_error(rtt_estimate, rtt_interval.lower, rtt_interval.upper) == pytest.approx(repeat_error)
+    assert maximum_relative_error(cets_estimate, cets_interval.lower, cets_interval.upper) == pytest.approx(repeat_error)
+
+
+def test_required_repeats_probability_error_bound_matches_paper_equation():
+    assert required_repeats_for_probability_error(0.01) == 9600
+    assert required_repeats_for_probability_error(0.03) == 1064
+
+
+def test_required_repeats_lower_bound_and_exact_search_are_deterministic():
+    assert required_repeats_lower_bound(0.1, 0.1) == 4180
+    assert required_repeats_exact(0.1, 0.1) == 4605
+    assert required_repeats_exact(0.01, 0.1) > required_repeats_exact(0.1, 0.1)
+    assert required_repeats_exact(0.1, 0.1) > required_repeats_exact(0.5, 0.1)
+
+
+def test_fixed_seed_bernoulli_rc_interval_is_asymmetric():
+    rng = np.random.default_rng(202603)
+    successes = int(rng.binomial(100, 0.1))
+
+    interval = agresti_coull_interval(successes, 100)
+    repeat_estimate = repeat_count(interval.estimate)
+    repeat_interval = repeat_count_interval(interval.lower, interval.upper)
+
+    assert successes == 13
+    assert repeat_interval.upper - repeat_estimate > repeat_estimate - repeat_interval.lower
+
+
+def test_fixed_seed_low_success_probability_requires_more_repeats():
+    rng = np.random.default_rng(202604)
+    low_successes = int(rng.binomial(1000, 0.1))
+    medium_successes = int(rng.binomial(1000, 0.5))
+
+    low_estimate = agresti_coull_interval(low_successes, 1000).estimate
+    medium_estimate = agresti_coull_interval(medium_successes, 1000).estimate
+
+    assert low_estimate < medium_estimate
+    assert required_repeats_lower_bound(low_estimate, 0.1) > required_repeats_lower_bound(medium_estimate, 0.1)
+
+
+def test_fixed_seed_noisy_point_estimates_can_invert_rankings():
+    rng = np.random.default_rng(1)
+    better_true_successes = int(rng.binomial(100, 0.25))
+    worse_true_successes = int(rng.binomial(100, 0.2))
+
+    better_estimate = agresti_coull_interval(better_true_successes, 100).estimate
+    worse_estimate = agresti_coull_interval(worse_true_successes, 100).estimate
+
+    assert better_true_successes == 25
+    assert worse_true_successes == 27
+    assert better_estimate < worse_estimate
+    assert repeat_count(better_estimate) > repeat_count(worse_estimate)

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -57,6 +57,12 @@ class TestImports:
         assert hasattr(success_metrics, 'Response')
         assert hasattr(success_metrics, 'PerfRatio')
         assert hasattr(success_metrics, 'SuccessProb')
+
+    def test_import_repeat_reliability(self):
+        """Test importing repeat reliability reference formulas."""
+        import repeat_reliability
+        assert hasattr(repeat_reliability, 'agresti_coull_interval')
+        assert hasattr(repeat_reliability, 'repeat_count')
     
     def test_import_training(self):
         """Test importing training module."""


### PR DESCRIPTION
## Summary

- Adds `src/repeat_reliability.py` with deterministic Noori et al. reference formulas for Agresti-Coull success-probability intervals, induced `R_c` intervals, RTT/CETS scaling, maximum relative error, and required repeat counts.
- Adds a validation note mapping paper equations to repository functions and test coverage.
- Adds deterministic fixtures and fixed-seed Bernoulli tests covering the issue's validation requirements.

## Tests run

- `python -m pytest tests/test_repeat_reliability.py -v` - passed, 45 tests.
- `python -m pytest tests/test_repeat_reliability.py --cov=repeat_reliability --cov-report=term-missing -q` - passed, 45 tests, 100% coverage for `src/repeat_reliability.py`.
- `python -m pytest tests/test_smoke.py tests/test_repeat_reliability.py -v` - passed, 67 tests.
- `flake8 src --count --select=E9,F63,F7,F82 --show-source --statistics` - passed, 0 critical issues.
- `flake8 src/repeat_reliability.py --count --exit-zero --max-complexity=10 --max-line-length=120 --statistics` - passed, 0 warnings.
- `git diff --check` - passed.
- `python run_tests.py integration` - passed, 11 tests.
- `python run_tests.py unit --fast` - 337 passed, 2 failed.

## Notes about tests not run

The full unit runner failures are pre-existing local environment failures in `tests/test_interpolate.py`, caused by `tqdm` calling pandas internals removed from this installed pandas version:

- `tests/test_interpolate.py::TestInterpolate::test_interpolate_basic`
- `tests/test_interpolate.py::TestInterpolateReduceMem::test_interpolate_reduce_mem_basic`

The failing stack is in `tqdm/std.py` / `pandas.core.groupby.groupby.py` while calling existing `progress_apply`; this PR does not modify `src/interpolate.py` or those tests.

Full `./run-ci-tests.sh` and tutorial notebook execution were not run locally after the documented unit runner stopped on the unrelated `tqdm`/pandas compatibility failure.

Closes #72