### PR TITLE
Implement repeat reliability math API

### DIFF
--- a/docs/noori_repeat_reliability_validation.md
+++ b/docs/noori_repeat_reliability_validation.md
@@ -5,10 +5,10 @@ formulas without an author reference implementation, executable code, or raw
 numerical data. The formulas are implemented as deterministic reference helpers
 in `src/repeat_reliability.py`; downstream production integrations should cite
 the same equation labels and reuse these tests when behavior is changed.
-The API uses `confidence_fraction` for statistical confidence-interval coverage
-and `target_confidence` for the `R_c` target probability, so callers do not
-confuse these fractional values with the percentage-style `confidence_level`
-arguments used elsewhere in the repository.
+The public API accepts percentage-style `confidence_level` values, matching the
+default conventions used elsewhere in this repository. Lower-level validation
+helpers retain `confidence_fraction` for equation-oriented tests. In both cases,
+`target_confidence` is the fractional `R_c` target probability.
 
 Paper reference:
 
@@ -31,6 +31,7 @@ optimizers: Avoiding unreliable conclusions." Physical Review Applied 25, no. 3
 | Eq. (13), maximum relative error in `R_c` | `maximum_relative_error` | Deterministic fixture grid checks exact relative-error values for finite intervals. |
 | Eq. (19), lower-bound repeats for target `R_c` relative error | `required_repeats_lower_bound` | Numeric checks and qualitative fixed-seed Bernoulli tests cover monotonic behavior for low vs. moderate success probabilities. |
 | Exact numerical repeats for target `R_c` relative error | `required_repeats_exact` | Binary-search numerical checks assert stable required-repeat values and compare them with lower-bound behavior. |
+| Public repeat-reliability workflow API | `repeat_reliability_metrics`, `repeats_to_solution`, `propagate_success_probability_interval`, `relative_repeats_error`, `required_trials_for_relative_error` | Wrapper tests cover dataframe-friendly output, boundary handling, interval propagation to `R_c`/RTT/CETS, and exact-vs-bound required-trial behavior. |
 
 ## Validation Strategy
 

--- a/src/repeat_reliability.py
+++ b/src/repeat_reliability.py
@@ -1,15 +1,43 @@
-"""Reference formulas for repeat-reliability validation.
+"""Repeat reliability primitives for stochastic optimizer evaluations.
 
-The functions in this module are small, deterministic implementations of the
-equations from Noori et al., "A Statistical Analysis for Per-Instance
-Evaluation of Stochastic Optimizers: Avoiding Unreliable Conclusions."
-They are intended as reviewable references for tests and later integrations.
+This module contains deterministic implementations of the repeat-reliability
+formulas used in Noori et al., "Statistical analysis for per-instance
+evaluation of stochastic optimizers: Avoiding unreliable conclusions."
+The helpers are independent from the existing bootstrap pipeline.
 """
+
+from __future__ import annotations
 
 from dataclasses import dataclass
 import math
+from typing import Literal
 
 from scipy import stats as scipy_stats
+
+
+DEFAULT_CONFIDENCE_LEVEL = 95.0
+DEFAULT_CONFIDENCE_FRACTION = 0.95
+DEFAULT_TARGET_CONFIDENCE = 0.99
+DEFAULT_RELATIVE_ERROR_THRESHOLD = 0.10
+
+
+@dataclass(frozen=True)
+class IntervalEstimate:
+    """Structured point estimate and confidence interval."""
+
+    estimate: float
+    lower: float
+    upper: float
+
+    def to_dict(self, prefix: str = "") -> dict[str, float]:
+        return _prefixed_dict(
+            prefix,
+            {
+                "estimate": self.estimate,
+                "lower": self.lower,
+                "upper": self.upper,
+            },
+        )
 
 
 @dataclass(frozen=True)
@@ -20,6 +48,14 @@ class ProportionInterval:
     lower: float
     upper: float
     half_width: float
+    successes: float | None = None
+    trials: int | None = None
+    confidence_level: float | None = None
+    confidence_fraction: float | None = None
+    z_value: float | None = None
+    adjusted_successes: float | None = None
+    adjusted_trials: float | None = None
+    raw_estimate: float | None = None
 
     @property
     def width(self) -> float:
@@ -31,6 +67,34 @@ class ProportionInterval:
             return math.inf
         return self.width / self.estimate
 
+    def to_interval(self) -> IntervalEstimate:
+        return IntervalEstimate(self.estimate, self.lower, self.upper)
+
+    def to_dict(self, prefix: str = "success_probability") -> dict[str, float | int]:
+        values: dict[str, float | int] = {
+            "estimate": self.estimate,
+            "lower": self.lower,
+            "upper": self.upper,
+            "half_width": self.half_width,
+        }
+        optional_values = {
+            "successes": self.successes,
+            "trials": self.trials,
+            "confidence_level": self.confidence_level,
+            "confidence_fraction": self.confidence_fraction,
+            "z_value": self.z_value,
+            "adjusted_successes": self.adjusted_successes,
+            "adjusted_trials": self.adjusted_trials,
+            "raw_estimate": self.raw_estimate,
+        }
+        values.update(
+            {key: value for key, value in optional_values.items() if value is not None}
+        )
+        return _prefixed_dict(prefix, values)
+
+
+AgrestiCoullInterval = ProportionInterval
+
 
 @dataclass(frozen=True)
 class RepeatCountInterval:
@@ -40,90 +104,150 @@ class RepeatCountInterval:
     upper: float
 
 
-def normal_critical_value(confidence_fraction: float = 0.95) -> float:
+@dataclass(frozen=True)
+class MetricInterval:
+    """Structured interval for propagated repeat-derived metrics."""
+
+    estimate: float
+    lower: float
+    upper: float
+    relative_error: float
+
+    def to_dict(self, prefix: str) -> dict[str, float]:
+        return _prefixed_dict(
+            prefix,
+            {
+                "estimate": self.estimate,
+                "lower": self.lower,
+                "upper": self.upper,
+                "relative_error": self.relative_error,
+            },
+        )
+
+
+@dataclass(frozen=True)
+class RepeatReliabilityMetrics:
+    """Probability, R_c, RTT, and CETS estimates with propagated intervals."""
+
+    success_probability: ProportionInterval | IntervalEstimate
+    r_c: MetricInterval
+    rtt: MetricInterval
+    cets: MetricInterval
+    target_confidence: float
+    rtt_factor: float
+    iterations: float
+    effort_per_iteration: float
+
+    def to_dict(self) -> dict[str, float | int]:
+        data: dict[str, float | int] = {}
+        data.update(self.success_probability.to_dict("success_probability"))
+        data.update(self.r_c.to_dict("r_c"))
+        data.update(self.rtt.to_dict("rtt"))
+        data.update(self.cets.to_dict("cets"))
+        data.update(
+            {
+                "target_confidence": self.target_confidence,
+                "rtt_factor": self.rtt_factor,
+                "iterations": self.iterations,
+                "effort_per_iteration": self.effort_per_iteration,
+            }
+        )
+        return data
+
+
+def normal_critical_value(confidence_fraction: float = DEFAULT_CONFIDENCE_FRACTION) -> float:
     """Return z_alpha for a two-sided confidence interval."""
 
-    _validate_open_probability(confidence_fraction, "confidence_fraction")
-    return float(scipy_stats.norm.ppf(0.5 + confidence_fraction / 2.0))
+    confidence = _validate_open_probability(confidence_fraction, "confidence_fraction")
+    return float(scipy_stats.norm.ppf(0.5 + confidence / 2.0))
 
 
 def agresti_coull_interval(
     successes: float,
-    repeats: int,
-    confidence_fraction: float = 0.95,
+    repeats: int | None = None,
+    confidence_level: float = DEFAULT_CONFIDENCE_LEVEL,
+    *,
+    trials: int | None = None,
+    confidence_fraction: float | None = None,
 ) -> ProportionInterval:
-    """Compute the Agresti-Coull interval from paper Eq. (8).
+    """Compute the Agresti-Coull interval for a Bernoulli success probability.
 
-    Eq. (8) defines n_hat = n + z_alpha^2, n_s_hat = n_s + z_alpha^2 / 2,
-    p_hat = n_s_hat / n_hat, and the interval
-    p_hat +/- z_alpha * sqrt(p_hat * (1 - p_hat) / n_hat).
+    ``confidence_level`` may be provided as a percentage (95) or a fraction
+    (0.95). ``confidence_fraction`` is retained for compatibility with the
+    validation helpers introduced for issue #72. Zero trials are defined by the
+    adjusted Agresti-Coull formula and return an adjusted estimate of 0.5 with a
+    clipped interval of [0, 1].
     """
 
-    if repeats <= 0:
-        raise ValueError("repeats must be positive")
-    if successes < 0 or successes > repeats:
-        raise ValueError("successes must be between 0 and repeats")
-
-    z = normal_critical_value(confidence_fraction)
-    adjusted_repeats = repeats + z**2
-    estimate = (successes + z**2 / 2.0) / adjusted_repeats
-    half_width = z * math.sqrt(estimate * (1.0 - estimate) / adjusted_repeats)
-    return ProportionInterval(
-        estimate=estimate,
-        lower=max(0.0, estimate - half_width),
-        upper=min(1.0, estimate + half_width),
-        half_width=half_width,
+    repeat_count_value = _coerce_repeats_argument(repeats, trials)
+    return _compute_agresti_coull_interval(
+        successes,
+        repeat_count_value,
+        _confidence_fraction_from_level(confidence_level, confidence_fraction),
+        require_integer_successes=True,
+        allow_zero_repeats=True,
     )
 
 
 def agresti_coull_interval_from_estimate(
     success_probability: float,
     repeats: int,
-    confidence_fraction: float = 0.95,
+    confidence_fraction: float = DEFAULT_CONFIDENCE_FRACTION,
 ) -> ProportionInterval:
-    """Compute Eq. (8) from an observed success fraction n_s / n."""
+    """Compute the Agresti-Coull interval from an observed success fraction."""
 
-    _validate_probability(success_probability, "success_probability")
-    return agresti_coull_interval(
-        successes=success_probability * repeats,
-        repeats=repeats,
-        confidence_fraction=confidence_fraction,
+    probability = _validate_probability(success_probability, "success_probability")
+    repeat_count_value = _validate_repeats(repeats, "repeats", allow_zero=False)
+    return _compute_agresti_coull_interval(
+        probability * repeat_count_value,
+        repeat_count_value,
+        confidence_fraction,
+        require_integer_successes=False,
+        allow_zero_repeats=False,
     )
 
 
 def success_probability_margin(
     adjusted_success_probability: float,
     repeats: int,
-    confidence_fraction: float = 0.95,
+    confidence_fraction: float = DEFAULT_CONFIDENCE_FRACTION,
 ) -> float:
-    """Return epsilon_p from paper Eq. (11) for an adjusted p_hat."""
+    """Return epsilon_p from the paper for an adjusted p_hat."""
 
-    _validate_probability(adjusted_success_probability, "adjusted_success_probability")
-    if repeats <= 0:
-        raise ValueError("repeats must be positive")
+    probability = _validate_probability(
+        adjusted_success_probability,
+        "adjusted_success_probability",
+    )
+    repeat_count_value = _validate_repeats(repeats, "repeats", allow_zero=False)
 
     z = normal_critical_value(confidence_fraction)
-    adjusted_repeats = repeats + z**2
-    return z * math.sqrt(
-        adjusted_success_probability * (1.0 - adjusted_success_probability)
-        / adjusted_repeats
-    )
+    adjusted_repeats = repeat_count_value + z**2
+    return z * math.sqrt(probability * (1.0 - probability) / adjusted_repeats)
 
 
 def repeat_count(success_probability: float, target_confidence: float = 0.99) -> float:
-    """Compute R_c from paper Eqs. (1) and (2)."""
+    """Compute R_c from the success probability and target confidence."""
 
-    _validate_probability(success_probability, "success_probability")
-    _validate_open_probability(target_confidence, "target_confidence")
+    probability = _validate_probability(success_probability, "success_probability")
+    target = _validate_open_probability(target_confidence, "target_confidence")
 
-    if success_probability == 0:
+    if probability == 0:
         return math.inf
-    if success_probability >= target_confidence:
+    if probability >= target:
         return 1.0
     return max(
-        math.log1p(-target_confidence) / math.log1p(-success_probability),
+        math.log1p(-target) / math.log1p(-probability),
         1.0,
     )
+
+
+def repeats_to_solution(
+    p: float,
+    target_confidence: float = DEFAULT_TARGET_CONFIDENCE,
+) -> float:
+    """Return the continuous R_c repeats needed to succeed with confidence c."""
+
+    return repeat_count(p, target_confidence=target_confidence)
 
 
 def repeat_count_interval(
@@ -131,22 +255,23 @@ def repeat_count_interval(
     success_probability_upper: float,
     target_confidence: float = 0.99,
 ) -> RepeatCountInterval:
-    """Induce an R_c interval from a probability interval.
+    """Induce an R_c interval from a probability interval."""
 
-    This implements the monotonic transformation described in the confidence
-    interval section: R_c^- uses the upper probability bound and R_c^+ uses the
-    lower probability bound.
-    """
-
-    _validate_probability(success_probability_lower, "success_probability_lower")
-    _validate_probability(success_probability_upper, "success_probability_upper")
+    lower_probability = _validate_probability(
+        success_probability_lower,
+        "success_probability_lower",
+    )
+    upper_probability = _validate_probability(
+        success_probability_upper,
+        "success_probability_upper",
+    )
     _validate_open_probability(target_confidence, "target_confidence")
-    if success_probability_lower > success_probability_upper:
+    if lower_probability > upper_probability:
         raise ValueError("success_probability_lower must be <= success_probability_upper")
 
     return RepeatCountInterval(
-        lower=repeat_count(success_probability_upper, target_confidence=target_confidence),
-        upper=repeat_count(success_probability_lower, target_confidence=target_confidence),
+        lower=repeat_count(upper_probability, target_confidence=target_confidence),
+        upper=repeat_count(lower_probability, target_confidence=target_confidence),
     )
 
 
@@ -155,7 +280,7 @@ def cets_from_repeat_count(
     iterations: float,
     effort_per_iteration: float = 1.0,
 ) -> float:
-    """Scale R_c to CETS from paper Eq. (3)."""
+    """Scale R_c to CETS."""
 
     if iterations < 0:
         raise ValueError("iterations must be non-negative")
@@ -197,7 +322,7 @@ def maximum_relative_error(
     lower: float,
     upper: float,
 ) -> float:
-    """Compute the maximum relative R_c error from paper Eq. (13)."""
+    """Compute the maximum relative R_c error."""
 
     if estimate <= 0 or not math.isfinite(estimate):
         return math.inf
@@ -206,12 +331,102 @@ def maximum_relative_error(
     return max(estimate - lower, upper - estimate, 0.0) / estimate
 
 
+def relative_repeats_error(r_c: float, r_c_lower: float, r_c_upper: float) -> float:
+    """Return max relative error for an R_c point estimate and interval."""
+
+    if r_c_lower > r_c or r_c_upper < r_c:
+        raise ValueError("repeat interval must satisfy lower <= estimate <= upper")
+    return maximum_relative_error(r_c, r_c_lower, r_c_upper)
+
+
+def propagate_success_probability_interval(
+    success_probability: float | IntervalEstimate | ProportionInterval,
+    probability_lower: float | None = None,
+    probability_upper: float | None = None,
+    *,
+    target_confidence: float = DEFAULT_TARGET_CONFIDENCE,
+    rtt_factor: float = 1.0,
+    iterations: float = 1.0,
+    effort_per_iteration: float = 1.0,
+) -> RepeatReliabilityMetrics:
+    """Propagate a success-probability interval to R_c, RTT, and CETS."""
+
+    probability_interval = _coerce_probability_interval(
+        success_probability,
+        probability_lower,
+        probability_upper,
+    )
+    target = _validate_open_probability(target_confidence, "target_confidence")
+    if rtt_factor < 0:
+        raise ValueError("rtt_factor must be non-negative")
+    if iterations < 0:
+        raise ValueError("iterations must be non-negative")
+    if effort_per_iteration < 0:
+        raise ValueError("effort_per_iteration must be non-negative")
+
+    r_c_estimate = repeat_count(probability_interval.estimate, target)
+    r_c_bounds = repeat_count_interval(
+        probability_interval.lower,
+        probability_interval.upper,
+        target_confidence=target,
+    )
+    r_c = MetricInterval(
+        estimate=r_c_estimate,
+        lower=r_c_bounds.lower,
+        upper=r_c_bounds.upper,
+        relative_error=maximum_relative_error(
+            r_c_estimate,
+            r_c_bounds.lower,
+            r_c_bounds.upper,
+        ),
+    )
+
+    rtt = _scale_metric_interval(r_c, rtt_factor)
+    cets = _scale_metric_interval(r_c, iterations * effort_per_iteration)
+    return RepeatReliabilityMetrics(
+        success_probability=probability_interval,
+        r_c=r_c,
+        rtt=rtt,
+        cets=cets,
+        target_confidence=target,
+        rtt_factor=rtt_factor,
+        iterations=iterations,
+        effort_per_iteration=effort_per_iteration,
+    )
+
+
+def repeat_reliability_metrics(
+    successes: float,
+    trials: int,
+    *,
+    confidence_level: float = DEFAULT_CONFIDENCE_LEVEL,
+    target_confidence: float = DEFAULT_TARGET_CONFIDENCE,
+    rtt_factor: float = 1.0,
+    iterations: float = 1.0,
+    effort_per_iteration: float = 1.0,
+) -> RepeatReliabilityMetrics:
+    """Compute Agresti-Coull probability and propagated repeat metrics."""
+
+    probability_interval = agresti_coull_interval(
+        successes,
+        trials=trials,
+        confidence_level=confidence_level,
+    )
+    return propagate_success_probability_interval(
+        probability_interval,
+        target_confidence=target_confidence,
+        rtt_factor=rtt_factor,
+        iterations=iterations,
+        effort_per_iteration=effort_per_iteration,
+    )
+
+
 def required_repeats_for_probability_error(
     error_tolerance: float,
-    confidence_fraction: float = 0.95,
+    confidence_fraction: float = DEFAULT_CONFIDENCE_FRACTION,
     min_repeats: int = 1,
 ) -> int:
-    """Return the worst-case n bound from paper Eq. (10)."""
+    """Return the worst-case n bound for an absolute probability error."""
 
     if error_tolerance <= 0:
         raise ValueError("error_tolerance must be positive")
@@ -226,27 +441,25 @@ def required_repeats_for_probability_error(
 def required_repeats_lower_bound(
     adjusted_success_probability: float,
     relative_error_threshold: float,
-    confidence_fraction: float = 0.95,
+    confidence_fraction: float = DEFAULT_CONFIDENCE_FRACTION,
     min_repeats: int = 1,
 ) -> float:
-    """Return the conservative lower-bound repeat count from paper Eq. (19)."""
+    """Return the closed-form lower-bound repeat count approximation."""
 
-    _validate_probability(adjusted_success_probability, "adjusted_success_probability")
+    probability = _validate_probability(
+        adjusted_success_probability,
+        "adjusted_success_probability",
+    )
     _validate_relative_error_threshold(relative_error_threshold)
     if min_repeats < 0:
         raise ValueError("min_repeats must be non-negative")
 
-    if adjusted_success_probability == 0:
+    if probability == 0:
         return math.inf
 
     z = normal_critical_value(confidence_fraction)
     threshold_factor = z * (1.0 + relative_error_threshold) / relative_error_threshold
-    bound = (
-        threshold_factor**2
-        * (1.0 - adjusted_success_probability)
-        / adjusted_success_probability
-        - z**2
-    )
+    bound = threshold_factor**2 * (1.0 - probability) / probability - z**2
     return max(min_repeats, math.ceil(bound))
 
 
@@ -254,32 +467,29 @@ def required_repeats_exact(
     adjusted_success_probability: float,
     relative_error_threshold: float,
     target_confidence: float = 0.99,
-    confidence_fraction: float = 0.95,
+    confidence_fraction: float = DEFAULT_CONFIDENCE_FRACTION,
     min_repeats: int = 1,
     max_repeats: int = 100_000_000,
 ) -> float:
-    """Find the smallest n whose induced R_c error satisfies Eq. (14).
+    """Find the smallest n whose induced R_c error satisfies the threshold."""
 
-    This is the exact numerical counterpart to the Eq. (19) lower bound. It
-    keeps p_hat fixed, uses Eq. (11) to compute epsilon_p(n), clips the induced
-    probability interval to [0, 1], and searches for the first n where the
-    induced Eq. (13) relative error is within the requested threshold.
-    """
-
-    _validate_probability(adjusted_success_probability, "adjusted_success_probability")
+    probability = _validate_probability(
+        adjusted_success_probability,
+        "adjusted_success_probability",
+    )
     _validate_relative_error_threshold(relative_error_threshold)
     _validate_open_probability(target_confidence, "target_confidence")
     if min_repeats <= 0:
         raise ValueError("min_repeats must be positive")
     if max_repeats < min_repeats:
         raise ValueError("max_repeats must be >= min_repeats")
-    if adjusted_success_probability == 0:
+    if probability == 0:
         return math.inf
 
-    estimate = repeat_count(adjusted_success_probability, target_confidence=target_confidence)
+    estimate = repeat_count(probability, target_confidence=target_confidence)
 
     if _repeat_count_error_satisfies_threshold(
-        adjusted_success_probability,
+        probability,
         estimate,
         min_repeats,
         relative_error_threshold,
@@ -293,7 +503,7 @@ def required_repeats_exact(
     while high < max_repeats:
         high = min(high * 2, max_repeats)
         if _repeat_count_error_satisfies_threshold(
-            adjusted_success_probability,
+            probability,
             estimate,
             high,
             relative_error_threshold,
@@ -308,7 +518,7 @@ def required_repeats_exact(
     while low < high:
         midpoint = (low + high) // 2
         if _repeat_count_error_satisfies_threshold(
-            adjusted_success_probability,
+            probability,
             estimate,
             midpoint,
             relative_error_threshold,
@@ -319,6 +529,78 @@ def required_repeats_exact(
         else:
             low = midpoint + 1
     return low
+
+
+def required_trials_for_relative_error(
+    p: float,
+    *,
+    relative_error_threshold: float = DEFAULT_RELATIVE_ERROR_THRESHOLD,
+    confidence_level: float = DEFAULT_CONFIDENCE_LEVEL,
+    target_confidence: float = DEFAULT_TARGET_CONFIDENCE,
+    method: Literal["exact", "bound"] = "exact",
+) -> int | float:
+    """Return trials needed to keep R_c relative error under a threshold."""
+
+    probability = _validate_probability(p, "p")
+    confidence_fraction = _confidence_fraction_from_level(confidence_level, None)
+    if method not in {"exact", "bound"}:
+        raise ValueError("method must be either 'exact' or 'bound'")
+    if probability == 1.0:
+        return 0
+
+    if method == "bound":
+        return required_repeats_lower_bound(
+            probability,
+            relative_error_threshold,
+            confidence_fraction=confidence_fraction,
+            min_repeats=0,
+        )
+    return required_repeats_exact(
+        probability,
+        relative_error_threshold,
+        target_confidence=target_confidence,
+        confidence_fraction=confidence_fraction,
+    )
+
+
+def _compute_agresti_coull_interval(
+    successes: float,
+    repeats: int,
+    confidence_fraction: float,
+    *,
+    require_integer_successes: bool,
+    allow_zero_repeats: bool,
+) -> ProportionInterval:
+    repeat_count_value = _validate_repeats(
+        repeats,
+        "repeats",
+        allow_zero=allow_zero_repeats,
+    )
+    success_count = _validate_successes(
+        successes,
+        repeat_count_value,
+        require_integer=require_integer_successes,
+    )
+
+    z = normal_critical_value(confidence_fraction)
+    adjusted_repeats = repeat_count_value + z**2
+    adjusted_successes = success_count + z**2 / 2.0
+    estimate = adjusted_successes / adjusted_repeats
+    half_width = z * math.sqrt(estimate * (1.0 - estimate) / adjusted_repeats)
+    return ProportionInterval(
+        estimate=estimate,
+        lower=max(0.0, estimate - half_width),
+        upper=min(1.0, estimate + half_width),
+        half_width=half_width,
+        successes=success_count,
+        trials=repeat_count_value,
+        confidence_level=confidence_fraction * 100.0,
+        confidence_fraction=confidence_fraction,
+        z_value=z,
+        adjusted_successes=adjusted_successes,
+        adjusted_trials=adjusted_repeats,
+        raw_estimate=success_count / repeat_count_value if repeat_count_value else math.nan,
+    )
 
 
 def _repeat_count_error_satisfies_threshold(
@@ -351,16 +633,127 @@ def _scale_repeat_count_value(repeats_to_confidence: float, scale: float) -> flo
     return scale * repeats_to_confidence
 
 
-def _validate_probability(value: float, name: str) -> None:
-    if not 0 <= value <= 1:
+def _scale_metric_interval(interval: MetricInterval, scale: float) -> MetricInterval:
+    return MetricInterval(
+        estimate=_scale_repeat_count_value(interval.estimate, scale),
+        lower=_scale_repeat_count_value(interval.lower, scale),
+        upper=_scale_repeat_count_value(interval.upper, scale),
+        relative_error=interval.relative_error,
+    )
+
+
+def _coerce_probability_interval(
+    success_probability: float | IntervalEstimate | ProportionInterval,
+    probability_lower: float | None,
+    probability_upper: float | None,
+) -> IntervalEstimate | ProportionInterval:
+    if isinstance(success_probability, (IntervalEstimate, ProportionInterval)):
+        if probability_lower is not None or probability_upper is not None:
+            raise ValueError("do not provide probability bounds with an interval object")
+        interval = success_probability
+    else:
+        if probability_lower is None or probability_upper is None:
+            raise ValueError("probability_lower and probability_upper are required")
+        interval = IntervalEstimate(
+            estimate=_validate_probability(success_probability, "success_probability"),
+            lower=_validate_probability(probability_lower, "probability_lower"),
+            upper=_validate_probability(probability_upper, "probability_upper"),
+        )
+
+    if interval.lower > interval.estimate or interval.upper < interval.estimate:
+        raise ValueError("probability interval must satisfy lower <= estimate <= upper")
+    return interval
+
+
+def _coerce_repeats_argument(repeats: int | None, trials: int | None) -> int:
+    if repeats is None and trials is None:
+        raise ValueError("trials must be provided")
+    if repeats is not None and trials is not None and repeats != trials:
+        raise ValueError("repeats and trials must match when both are provided")
+    return repeats if repeats is not None else trials
+
+
+def _confidence_fraction_from_level(
+    confidence_level: float,
+    confidence_fraction: float | None,
+) -> float:
+    if confidence_fraction is not None:
+        return _validate_open_probability(confidence_fraction, "confidence_fraction")
+
+    try:
+        level = float(confidence_level)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("confidence_level must be between 0 and 100") from exc
+    if level > 1.0:
+        level = level / 100.0
+    return _validate_open_probability(level, "confidence_level")
+
+
+def _prefixed_dict(prefix: str, values: dict[str, float | int]) -> dict[str, float | int]:
+    if not prefix:
+        return values
+    return {f"{prefix}_{key}": value for key, value in values.items()}
+
+
+def _validate_successes(
+    successes: float,
+    repeats: int,
+    *,
+    require_integer: bool,
+) -> float:
+    try:
+        success_count = float(successes)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("successes must be numeric") from exc
+    if not math.isfinite(success_count) or success_count < 0 or success_count > repeats:
+        raise ValueError("successes must be between 0 and repeats")
+    if require_integer and not success_count.is_integer():
+        raise ValueError("successes must be an integer count")
+    return int(success_count) if require_integer else success_count
+
+
+def _validate_repeats(value: int, name: str, *, allow_zero: bool) -> int:
+    if isinstance(value, bool):
+        raise ValueError(f"{name} must be an integer")
+    try:
+        repeats = float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{name} must be an integer") from exc
+    if not math.isfinite(repeats) or not repeats.is_integer():
+        raise ValueError(f"{name} must be an integer")
+    if allow_zero:
+        if repeats < 0:
+            raise ValueError(f"{name} must be non-negative")
+    elif repeats <= 0:
+        raise ValueError(f"{name} must be positive")
+    return int(repeats)
+
+
+def _validate_probability(value: float, name: str) -> float:
+    try:
+        probability = float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{name} must be between 0 and 1") from exc
+    if not math.isfinite(probability) or not 0 <= probability <= 1:
         raise ValueError(f"{name} must be between 0 and 1")
+    return probability
 
 
-def _validate_open_probability(value: float, name: str) -> None:
-    if not 0 < value < 1:
+def _validate_open_probability(value: float, name: str) -> float:
+    try:
+        probability = float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{name} must be between 0 and 1, exclusive") from exc
+    if not math.isfinite(probability) or not 0 < probability < 1:
         raise ValueError(f"{name} must be between 0 and 1, exclusive")
+    return probability
 
 
-def _validate_relative_error_threshold(value: float) -> None:
-    if not 0 < value < 1:
+def _validate_relative_error_threshold(value: float) -> float:
+    try:
+        threshold = float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("relative_error_threshold must be between 0 and 1") from exc
+    if not math.isfinite(threshold) or not 0 < threshold < 1:
         raise ValueError("relative_error_threshold must be between 0 and 1")
+    return threshold

--- a/src/repeat_reliability.py
+++ b/src/repeat_reliability.py
@@ -542,6 +542,8 @@ def required_trials_for_relative_error(
     """Return trials needed to keep R_c relative error under a threshold."""
 
     probability = _validate_probability(p, "p")
+    threshold = _validate_relative_error_threshold(relative_error_threshold)
+    target = _validate_open_probability(target_confidence, "target_confidence")
     confidence_fraction = _confidence_fraction_from_level(confidence_level, None)
     if method not in {"exact", "bound"}:
         raise ValueError("method must be either 'exact' or 'bound'")
@@ -551,14 +553,14 @@ def required_trials_for_relative_error(
     if method == "bound":
         return required_repeats_lower_bound(
             probability,
-            relative_error_threshold,
+            threshold,
             confidence_fraction=confidence_fraction,
             min_repeats=0,
         )
     return required_repeats_exact(
         probability,
-        relative_error_threshold,
-        target_confidence=target_confidence,
+        threshold,
+        target_confidence=target,
         confidence_fraction=confidence_fraction,
     )
 

--- a/tests/test_repeat_reliability.py
+++ b/tests/test_repeat_reliability.py
@@ -1,9 +1,11 @@
 import math
 
 import numpy as np
+import pandas as pd
 import pytest
 
 from repeat_reliability import (
+    IntervalEstimate,
     ProportionInterval,
     RepeatCountInterval,
     agresti_coull_interval,
@@ -11,11 +13,16 @@ from repeat_reliability import (
     cets_from_repeat_count,
     maximum_relative_error,
     normal_critical_value,
+    propagate_success_probability_interval,
+    relative_repeats_error,
     repeat_count,
     repeat_count_interval,
+    repeat_reliability_metrics,
+    repeats_to_solution,
     required_repeats_exact,
     required_repeats_for_probability_error,
     required_repeats_lower_bound,
+    required_trials_for_relative_error,
     rtt_from_repeat_count,
     scaled_repeat_count_interval,
     success_probability_margin,
@@ -86,6 +93,15 @@ def test_noori_reference_grid_matches_deterministic_fixtures(
         assert max_error == pytest.approx(expected_error, abs=5e-12)
 
 
+def test_public_agresti_coull_zero_trials_is_defined():
+    interval = agresti_coull_interval(0, 0)
+
+    assert interval.estimate == pytest.approx(0.5)
+    assert interval.lower == pytest.approx(0.0)
+    assert interval.upper == pytest.approx(1.0)
+    assert math.isnan(interval.raw_estimate)
+
+
 def test_rtt_and_cets_scaling_preserve_relative_error():
     repeat_estimate = repeat_count(0.25, target_confidence=0.99)
     repeat_interval = repeat_count_interval(0.22, 0.28, target_confidence=0.99)
@@ -114,6 +130,9 @@ def test_interval_width_properties_cover_zero_estimate():
     assert interval.width == pytest.approx(0.1)
     assert interval.relative_width == pytest.approx(0.4)
     assert math.isinf(zero_estimate_interval.relative_width)
+    assert interval.to_interval().estimate == pytest.approx(0.25)
+    assert interval.to_dict("")["estimate"] == pytest.approx(0.25)
+    assert IntervalEstimate(estimate=0.25, lower=0.2, upper=0.3).to_dict()["upper"] == pytest.approx(0.3)
 
 
 def test_required_repeats_probability_error_bound_matches_paper_equation():
@@ -132,18 +151,95 @@ def test_required_repeats_lower_bound_and_exact_search_are_deterministic():
     assert required_repeats_exact(1.0, 0.1) == 1
 
 
+def test_issue_73_dataframe_friendly_metrics_and_aliases():
+    metrics = repeat_reliability_metrics(
+        25,
+        100,
+        rtt_factor=3.0,
+        iterations=4,
+        effort_per_iteration=2.0,
+    )
+    df = pd.DataFrame([metrics.to_dict()])
+
+    assert repeats_to_solution(0.5) == pytest.approx(repeat_count(0.5))
+    assert "success_probability_estimate" in df.columns
+    assert "success_probability_successes" in df.columns
+    assert "r_c_relative_error" in df.columns
+    assert "rtt_estimate" in df.columns
+    assert "cets_estimate" in df.columns
+    assert df.loc[0, "success_probability_successes"] == 25
+    assert df.loc[0, "success_probability_trials"] == 100
+
+
+def test_issue_73_interval_propagation_and_relative_error():
+    metrics = propagate_success_probability_interval(
+        0.5,
+        0.4,
+        0.6,
+        rtt_factor=2.0,
+        iterations=10,
+        effort_per_iteration=0.5,
+    )
+
+    assert metrics.r_c.estimate == pytest.approx(repeat_count(0.5))
+    assert metrics.r_c.lower == pytest.approx(repeat_count(0.6))
+    assert metrics.r_c.upper == pytest.approx(repeat_count(0.4))
+    assert metrics.rtt.estimate == pytest.approx(metrics.r_c.estimate * 2.0)
+    assert metrics.cets.estimate == pytest.approx(metrics.r_c.estimate * 5.0)
+    assert relative_repeats_error(10.0, 8.0, 13.0) == pytest.approx(0.3)
+
+    with pytest.raises(ValueError):
+        relative_repeats_error(10.0, 11.0, 13.0)
+
+
+def test_issue_73_required_trials_wrapper_boundaries_and_methods():
+    exact = required_trials_for_relative_error(0.9, method="exact")
+    bound = required_trials_for_relative_error(0.9, method="bound")
+
+    assert exact > bound
+    assert required_trials_for_relative_error(0.1) > required_trials_for_relative_error(0.5)
+    assert math.isinf(required_trials_for_relative_error(0.0))
+    assert required_trials_for_relative_error(1.0) == 0
+
+    with pytest.raises(ValueError):
+        required_trials_for_relative_error(0.5, relative_error_threshold=0)
+    with pytest.raises(ValueError):
+        required_trials_for_relative_error(0.5, method="unsupported")
+
+
 @pytest.mark.parametrize(
     "call",
     [
         lambda: normal_critical_value(1.0),
-        lambda: agresti_coull_interval(0, 0),
+        lambda: normal_critical_value("bad"),
+        lambda: agresti_coull_interval(0),
+        lambda: agresti_coull_interval(0, 10, trials=11),
+        lambda: agresti_coull_interval("bad", 10),
         lambda: agresti_coull_interval(-1, 10),
+        lambda: agresti_coull_interval(1.5, 10),
+        lambda: agresti_coull_interval(0, True),
+        lambda: agresti_coull_interval(0, "bad"),
+        lambda: agresti_coull_interval(0, 1.5),
+        lambda: agresti_coull_interval(0, -1),
+        lambda: agresti_coull_interval(0, 10, confidence_level="bad"),
+        lambda: agresti_coull_interval(0, 10, confidence_fraction="bad"),
         lambda: agresti_coull_interval_from_estimate(-0.1, 10),
         lambda: success_probability_margin(0.5, 0),
+        lambda: repeat_count("bad"),
         lambda: repeat_count(0.5, target_confidence=0.0),
         lambda: repeat_count(0.5, target_confidence=1.0),
         lambda: repeat_count_interval(0.8, 0.2),
         lambda: repeat_count_interval(0.1, 0.2, target_confidence=0.0),
+        lambda: propagate_success_probability_interval(0.5),
+        lambda: propagate_success_probability_interval(0.5, 0.6, 0.4),
+        lambda: propagate_success_probability_interval(
+            ProportionInterval(estimate=0.5, lower=0.4, upper=0.6, half_width=0.1),
+            0.4,
+            0.6,
+        ),
+        lambda: propagate_success_probability_interval(0.5, 0.4, 0.6, rtt_factor=-1),
+        lambda: propagate_success_probability_interval(0.5, 0.4, 0.6, iterations=-1),
+        lambda: propagate_success_probability_interval(0.5, 0.4, 0.6, effort_per_iteration=-1),
         lambda: cets_from_repeat_count(1.0, iterations=-1),
         lambda: cets_from_repeat_count(1.0, iterations=1, effort_per_iteration=-1),
         lambda: cets_from_repeat_count(math.inf, iterations=0),
@@ -155,6 +251,7 @@ def test_required_repeats_lower_bound_and_exact_search_are_deterministic():
         lambda: required_repeats_for_probability_error(0.1, min_repeats=-1),
         lambda: required_repeats_lower_bound(0.5, 0.1, min_repeats=-1),
         lambda: required_repeats_lower_bound(0.5, 1.0),
+        lambda: required_repeats_lower_bound(0.5, "bad"),
         lambda: required_repeats_exact(0.5, 0.1, target_confidence=0.0),
         lambda: required_repeats_exact(0.5, 0.1, target_confidence=1.0),
         lambda: required_repeats_exact(0.5, 0.1, min_repeats=0),

--- a/tests/test_repeat_reliability.py
+++ b/tests/test_repeat_reliability.py
@@ -205,6 +205,12 @@ def test_issue_73_required_trials_wrapper_boundaries_and_methods():
         required_trials_for_relative_error(0.5, relative_error_threshold=0)
     with pytest.raises(ValueError):
         required_trials_for_relative_error(0.5, method="unsupported")
+    with pytest.raises(ValueError):
+        required_trials_for_relative_error(1.0, relative_error_threshold=0)
+    with pytest.raises(ValueError):
+        required_trials_for_relative_error(1.0, target_confidence=1.0)
+    with pytest.raises(ValueError):
+        required_trials_for_relative_error(0.5, method="bound", target_confidence=1.0)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -59,10 +59,12 @@ class TestImports:
         assert hasattr(success_metrics, 'SuccessProb')
 
     def test_import_repeat_reliability(self):
-        """Test importing repeat reliability reference formulas."""
+        """Test importing repeat_reliability module."""
         import repeat_reliability
         assert hasattr(repeat_reliability, 'agresti_coull_interval')
         assert hasattr(repeat_reliability, 'repeat_count')
+        assert hasattr(repeat_reliability, 'repeats_to_solution')
+        assert hasattr(repeat_reliability, 'required_trials_for_relative_error')
     
     def test_import_training(self):
         """Test importing training module."""


### PR DESCRIPTION
## Summary

- Extends `repeat_reliability` from validation-only formulas into a reusable math API for repeat reliability workflows.
- Adds structured interval/result objects with `to_dict()` output for dataframe/report use.
- Adds Agresti-Coull zero-trial behavior, `repeats_to_solution`, probability-interval propagation to `R_c`, RTT, and CETS, relative repeat error, and exact/bound required-trial wrappers.
- Preserves the issue #72 formula validation helpers and tests while adding issue #73 API coverage.

## Tests run

- `pytest tests/test_repeat_reliability.py -q` -> 75 passed
- `pytest tests/test_repeat_reliability.py --cov=repeat_reliability --cov-report=term-missing -q` -> 75 passed, 100% coverage for `src/repeat_reliability.py`
- `pytest tests/test_smoke.py -q` -> 22 passed
- `pytest tests/ -q` -> 387 passed, 12 warnings
- `flake8 src --count --select=E9,F63,F7,F82 --show-source --statistics` -> 0
- `flake8 src --count --exit-zero --max-complexity=10 --max-line-length=120 --statistics` -> exited 0; reported existing repository style warnings, with no findings in `src/repeat_reliability.py`

## Notes

- Local Python 3.12 is present but does not have pytest installed, so the CI matrix versions were not reproduced locally.

Closes #73
