### PR TITLE
Add passive reliability reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ Use the root README as the entry point, then follow the focused documents for th
 - [examples/general_workflow.md](examples/general_workflow.md) for the end-to-end benchmark flow
 - [CI-TESTING.md](CI-TESTING.md) for local CI reproduction and environment setup
 - [TESTING.md](TESTING.md) for the test suite overview
+- [docs/passive_repeat_reliability_reports.md](docs/passive_repeat_reliability_reports.md) for passive repeat-reliability report inputs, outputs, and joins
 - [docs/noori_repeat_reliability_validation.md](docs/noori_repeat_reliability_validation.md) for validation of Noori et al. repeat-reliability formulas
 - [examples/wishart_n_50_alpha_0.5/README.md](examples/wishart_n_50_alpha_0.5/README.md) for the Wishart example details
 

--- a/docs/passive_repeat_reliability_reports.md
+++ b/docs/passive_repeat_reliability_reports.md
@@ -1,0 +1,92 @@
+# Passive Repeat-Reliability Reports
+
+Passive repeat-reliability reports summarize existing solver observations. They do not run a solver or resample new data. Use them when each row already records a stochastic run, or when rows are pre-aggregated with a count column.
+
+## Input Shapes
+
+Run-level data should contain one row per observed run:
+
+```python
+from repeat_reliability import repeat_reliability_report
+
+report = repeat_reliability_report(
+    runs,
+    group_cols=["solver", "budget", "instance"],
+    response_col="energy",
+    success_rule="min",
+    threshold=-42.0,
+    rtt_factor="runtime_seconds",
+    iterations="num_reads",
+    effort_per_iteration="sweeps_per_read",
+)
+```
+
+Pre-aggregated data should use `count_col` for the number of identical observations represented by each row. Counts weight successes, trials, and resource-factor averages:
+
+```python
+report = repeat_reliability_report(
+    summarized_runs,
+    group_cols=["solver", "budget"],
+    success_col="solved",
+    count_col="n_runs",
+    rtt_factor="runtime_seconds",
+    iterations="num_reads",
+    effort_per_iteration="sweeps_per_read",
+)
+```
+
+`success_col` accepts booleans, `0`/`1`, and common boolean strings such as `"true"`, `"false"`, `"yes"`, `"no"`, `"1"`, and `"0"`. Null or ambiguous values are rejected so string values such as `"False"` are not accidentally treated as truthy.
+
+## Success Rules
+
+Use `success_col` when the input already contains a pass/fail indicator. Otherwise choose a rule and response columns:
+
+- `success_rule="min"`: success means `response_col <= threshold`.
+- `success_rule="max"`: success means `response_col >= threshold`.
+- `success_rule="absolute"`: success means `abs(response_col - target_value) <= threshold`.
+- `success_rule="gap"`, `"gap_min"`, or `"gap_max"`: success means the observed optimality gap is within `gap`.
+- `success_rule="PerfRatio"`: success is derived from a performance-ratio column or from `best_value`, `random_value`, and `response_dir`.
+
+All success rules are evaluated row by row before aggregation.
+
+## Output Columns
+
+The report preserves `group_cols` and any `comparison_cols`, followed by reliability metrics:
+
+- `successes`, `trials`, and `success_rate`.
+- `p_hat`: raw empirical success rate, `successes / trials`.
+- `adjusted_p_hat`, `p_ci_lower`, and `p_ci_upper`: Agresti-Coull adjusted estimate and interval.
+- `R_c`, `R_c_ci_lower`, and `R_c_ci_upper`: target-neutral repeat count for `target_confidence`.
+- A target-specific repeat-count alias, such as `R99` for `target_confidence=0.99` or `R95` for `target_confidence=0.95`.
+- `RTT` and `CETS` intervals. `CETS` uses `cets_factor`, the count-weighted per-row product of `iterations * effort_per_iteration`.
+- Reliability status columns, including `required_trials`, `additional_trials_required`, `reliable`, and `reliability_status`.
+- Comparison flags, when enabled: `best_point_estimate`, `ci_overlaps_best`, and `statistically_unresolved`.
+
+Lower `R_c`, `RTT`, and `CETS` values are better. For probability-like comparison columns, call `annotate_reliability_comparisons` with `objective="max"`.
+
+## Benchmark Wrapper
+
+`StochasticBenchmark.run_RepeatReliability` forwards keyword arguments to `repeat_reliability_report`:
+
+```python
+report = benchmark.run_RepeatReliability(
+    response_col="energy",
+    success_rule="min",
+    threshold=-42.0,
+    rtt_factor="runtime_seconds",
+    iterations="num_reads",
+    effort_per_iteration="sweeps_per_read",
+)
+```
+
+If `df` is omitted, the wrapper uses the first populated DataFrame among `raw_data`, `bs_results`, and `interp_results`. If `group_cols` is omitted, it groups by `parameter_names + instance_cols`.
+
+Reports are flat DataFrames and can be joined to benchmark outputs on the group columns:
+
+```python
+joined = recommendations.merge(
+    report,
+    on=["solver", "budget", "instance"],
+    how="left",
+)
+```

--- a/docs/passive_repeat_reliability_reports.md
+++ b/docs/passive_repeat_reliability_reports.md
@@ -45,7 +45,7 @@ Use `success_col` when the input already contains a pass/fail indicator. Otherwi
 - `success_rule="max"`: success means `response_col >= threshold`.
 - `success_rule="absolute"`: success means `abs(response_col - target_value) <= threshold`.
 - `success_rule="gap"`, `"gap_min"`, or `"gap_max"`: success means the observed optimality gap is within `gap`.
-- `success_rule="PerfRatio"`: success is derived from a performance-ratio column or from `best_value`, `random_value`, and `response_dir`.
+- `success_rule="PerfRatio"`: success means an existing performance-ratio column, selected with `perf_ratio_col` or `response_col`, is greater than or equal to `threshold`.
 
 All success rules are evaluated row by row before aggregation.
 
@@ -66,7 +66,7 @@ Lower `R_c`, `RTT`, and `CETS` values are better. For probability-like compariso
 
 ## Benchmark Wrapper
 
-`StochasticBenchmark.run_RepeatReliability` forwards keyword arguments to `repeat_reliability_report`:
+`stochastic_benchmark.run_RepeatReliability` forwards keyword arguments to `repeat_reliability_report`:
 
 ```python
 report = benchmark.run_RepeatReliability(

--- a/src/repeat_reliability.py
+++ b/src/repeat_reliability.py
@@ -514,15 +514,25 @@ def repeat_reliability_report(
             weight_col="_repeat_reliability_count",
             name="effort_per_iteration",
         )
+        cets_scale = _weighted_product_group_value(
+            group,
+            iterations,
+            effort_per_iteration,
+            weight_col="_repeat_reliability_count",
+            left_name="iterations",
+            right_name="effort_per_iteration",
+            result_name="cets_factor",
+        )
         metrics = repeat_reliability_metrics(
             successes,
             trials,
             confidence_level=confidence_level,
             target_confidence=target_confidence,
             rtt_factor=rtt_scale,
-            iterations=iteration_scale,
-            effort_per_iteration=effort_scale,
+            iterations=cets_scale,
+            effort_per_iteration=1.0,
         )
+        p_hat = successes / trials if trials else math.nan
         required_trials = required_trials_for_relative_error(
             metrics.success_probability.estimate,
             relative_error_threshold=relative_error_threshold,
@@ -540,14 +550,15 @@ def repeat_reliability_report(
             {
                 "successes": successes,
                 "trials": trials,
-                "success_rate": successes / trials if trials else math.nan,
-                "p_hat": metrics.success_probability.estimate,
+                "success_rate": p_hat,
+                "p_hat": p_hat,
+                "adjusted_p_hat": metrics.success_probability.estimate,
                 "p_ci_lower": metrics.success_probability.lower,
                 "p_ci_upper": metrics.success_probability.upper,
                 "p_ci_half_width": metrics.success_probability.half_width,
-                "R99": metrics.r_c.estimate,
-                "R99_ci_lower": metrics.r_c.lower,
-                "R99_ci_upper": metrics.r_c.upper,
+                "R_c": metrics.r_c.estimate,
+                "R_c_ci_lower": metrics.r_c.lower,
+                "R_c_ci_upper": metrics.r_c.upper,
                 "RTT": metrics.rtt.estimate,
                 "RTT_ci_lower": metrics.rtt.lower,
                 "RTT_ci_upper": metrics.rtt.upper,
@@ -568,15 +579,21 @@ def repeat_reliability_report(
                 "rtt_factor": rtt_scale,
                 "iterations": iteration_scale,
                 "effort_per_iteration": effort_scale,
+                "cets_factor": cets_scale,
             }
         )
+        record.update(_target_repeat_count_columns(metrics.r_c, target_confidence))
         records.append(record)
 
     report = (
         pd.DataFrame.from_records(records)
         if records
         else pd.DataFrame(
-            columns=_repeat_reliability_report_columns(groups, comparison_cols)
+            columns=_repeat_reliability_report_columns(
+                groups,
+                comparison_cols,
+                target_confidence,
+            )
         )
     )
     if add_comparison_flags:
@@ -592,14 +609,14 @@ def annotate_reliability_comparisons(
     df: pd.DataFrame,
     *,
     comparison_cols: str | Sequence[str] | None = None,
-    estimate_col: str = "R99",
-    lower_col: str = "R99_ci_lower",
-    upper_col: str = "R99_ci_upper",
+    estimate_col: str = "R_c",
+    lower_col: str = "R_c_ci_lower",
+    upper_col: str = "R_c_ci_upper",
     objective: str | int = "min",
 ) -> pd.DataFrame:
     """Flag point-estimate winners whose confidence intervals are unresolved.
 
-    The default objective is minimization because lower R99/RTT/CETS values are
+    The default objective is minimization because lower R_c/RTT/CETS values are
     better. For probability-like metrics, pass ``objective="max"`` and the
     corresponding estimate/interval columns.
     """
@@ -665,23 +682,29 @@ def annotate_reliability_comparisons(
 def _repeat_reliability_report_columns(
     group_cols: Sequence[str],
     comparison_cols: str | Sequence[str] | None,
+    target_confidence: float,
 ) -> list[str]:
     columns = list(group_cols)
     for column in _coerce_column_list(comparison_cols):
         if column not in columns:
             columns.append(column)
+    repeat_label = _target_repeat_count_label(target_confidence)
     columns.extend(
         [
             "successes",
             "trials",
             "success_rate",
             "p_hat",
+            "adjusted_p_hat",
             "p_ci_lower",
             "p_ci_upper",
             "p_ci_half_width",
-            "R99",
-            "R99_ci_lower",
-            "R99_ci_upper",
+            "R_c",
+            "R_c_ci_lower",
+            "R_c_ci_upper",
+            repeat_label,
+            f"{repeat_label}_ci_lower",
+            f"{repeat_label}_ci_upper",
             "RTT",
             "RTT_ci_lower",
             "RTT_ci_upper",
@@ -699,6 +722,7 @@ def _repeat_reliability_report_columns(
             "rtt_factor",
             "iterations",
             "effort_per_iteration",
+            "cets_factor",
         ]
     )
     return columns
@@ -889,6 +913,24 @@ def _count_series(df: pd.DataFrame, count_col: str | None) -> pd.Series:
     return counts.astype(float)
 
 
+def _target_repeat_count_columns(
+    interval: MetricInterval,
+    target_confidence: float,
+) -> dict[str, float]:
+    repeat_label = _target_repeat_count_label(target_confidence)
+    return {
+        repeat_label: interval.estimate,
+        f"{repeat_label}_ci_lower": interval.lower,
+        f"{repeat_label}_ci_upper": interval.upper,
+    }
+
+
+def _target_repeat_count_label(target_confidence: float) -> str:
+    target = _validate_open_probability(target_confidence, "target_confidence")
+    percent = f"{target * 100.0:g}".replace(".", "_")
+    return f"R{percent}"
+
+
 def _success_series(
     df: pd.DataFrame,
     *,
@@ -906,10 +948,7 @@ def _success_series(
 ) -> pd.Series:
     if success_col is not None:
         _require_columns(df, [success_col])
-        successes = df[success_col]
-        if successes.isna().any():
-            raise ValueError("success_col must not contain null values")
-        return successes.astype(bool)
+        return _success_indicator_series(df[success_col])
 
     rule = _canonical_success_rule(success_rule)
     if rule == "perf_ratio":
@@ -944,6 +983,34 @@ def _success_series(
         )
 
     raise ValueError("unsupported success_rule: {}".format(success_rule))
+
+
+def _success_indicator_series(series: pd.Series) -> pd.Series:
+    if series.isna().any():
+        raise ValueError("success_col must not contain null values")
+    return series.map(_coerce_success_indicator).astype(bool)
+
+
+def _coerce_success_indicator(value) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"true", "t", "yes", "y", "1"}:
+            return True
+        if normalized in {"false", "f", "no", "n", "0"}:
+            return False
+        raise ValueError("success_col must contain boolean or 0/1 values")
+
+    try:
+        numeric = float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("success_col must contain boolean or 0/1 values") from exc
+    if numeric == 1.0:
+        return True
+    if numeric == 0.0:
+        return False
+    raise ValueError("success_col must contain boolean or 0/1 values")
 
 
 def _gap_success_series(
@@ -1060,6 +1127,28 @@ def _weighted_group_value(
     values = _numeric_series(group, value, name)
     if (values < 0).any():
         raise ValueError("{} must be non-negative".format(name))
+    weights = group[weight_col].astype(float)
+    total_weight = weights.sum()
+    if total_weight == 0:
+        return float(values.mean())
+    return float((values * weights).sum() / total_weight)
+
+
+def _weighted_product_group_value(
+    group: pd.DataFrame,
+    left: float | str,
+    right: float | str,
+    *,
+    weight_col: str,
+    left_name: str,
+    right_name: str,
+    result_name: str,
+) -> float:
+    left_values = _numeric_series(group, left, left_name)
+    right_values = _numeric_series(group, right, right_name)
+    if (left_values < 0).any() or (right_values < 0).any():
+        raise ValueError("{} must be non-negative".format(result_name))
+    values = left_values * right_values
     weights = group[weight_col].astype(float)
     total_weight = weights.sum()
     if total_weight == 0:

--- a/src/repeat_reliability.py
+++ b/src/repeat_reliability.py
@@ -8,10 +8,12 @@ The helpers are independent from the existing bootstrap pipeline.
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from dataclasses import dataclass
 import math
 from typing import Literal
 
+import pandas as pd
 from scipy import stats as scipy_stats
 
 
@@ -421,6 +423,287 @@ def repeat_reliability_metrics(
     )
 
 
+def repeat_reliability_report(
+    df: pd.DataFrame,
+    *,
+    group_cols: str | Sequence[str] | None = None,
+    response_col: str | None = None,
+    success_col: str | None = None,
+    count_col: str | None = None,
+    success_rule: str = "min",
+    threshold: float | str | None = None,
+    response_dir: str | int = "min",
+    target_value: float | str = 0.0,
+    best_value: float | str | None = None,
+    random_value: float | str | None = None,
+    gap: float | None = None,
+    gap_is_percent: bool = False,
+    perf_ratio_col: str | None = None,
+    rtt_factor: float | str = 1.0,
+    iterations: float | str = 1.0,
+    effort_per_iteration: float | str = 1.0,
+    confidence_level: float = DEFAULT_CONFIDENCE_LEVEL,
+    target_confidence: float = DEFAULT_TARGET_CONFIDENCE,
+    relative_error_threshold: float = DEFAULT_RELATIVE_ERROR_THRESHOLD,
+    required_trials_method: Literal["exact", "bound"] = "exact",
+    comparison_cols: str | Sequence[str] | None = None,
+    comparison_objective: str | int = "min",
+    add_comparison_flags: bool = True,
+) -> pd.DataFrame:
+    """Build a passive repeat-reliability report from existing observations.
+
+    The input may contain one row per run or pre-aggregated rows with
+    ``count_col``. Successes are evaluated row-wise, weighted by ``count_col``
+    when provided, and summarized over ``group_cols``. The returned dataframe is
+    flat and keeps group columns intact so it can be joined to bootstrap,
+    interpolation, recommendation, or HPO-style outputs.
+    """
+
+    if not isinstance(df, pd.DataFrame):
+        raise TypeError("df must be a pandas DataFrame")
+
+    groups = _coerce_column_list(group_cols)
+    _require_columns(df, groups)
+    if count_col is not None:
+        _require_columns(df, [count_col])
+
+    work = df.copy()
+    work["_repeat_reliability_count"] = _count_series(work, count_col)
+    work["_repeat_reliability_success"] = _success_series(
+        work,
+        response_col=response_col,
+        success_col=success_col,
+        success_rule=success_rule,
+        threshold=threshold,
+        response_dir=response_dir,
+        target_value=target_value,
+        best_value=best_value,
+        random_value=random_value,
+        gap=gap,
+        gap_is_percent=gap_is_percent,
+        perf_ratio_col=perf_ratio_col,
+    )
+    work["_repeat_reliability_success_count"] = (
+        work["_repeat_reliability_success"].astype(float)
+        * work["_repeat_reliability_count"]
+    )
+
+    records = []
+    for key, group in _iter_groups(work, groups):
+        record = dict(zip(groups, key))
+        successes = _integer_count(
+            group["_repeat_reliability_success_count"].sum(),
+            "successes",
+        )
+        trials = _integer_count(group["_repeat_reliability_count"].sum(), "trials")
+        rtt_scale = _weighted_group_value(
+            group,
+            rtt_factor,
+            weight_col="_repeat_reliability_count",
+            name="rtt_factor",
+        )
+        iteration_scale = _weighted_group_value(
+            group,
+            iterations,
+            weight_col="_repeat_reliability_count",
+            name="iterations",
+        )
+        effort_scale = _weighted_group_value(
+            group,
+            effort_per_iteration,
+            weight_col="_repeat_reliability_count",
+            name="effort_per_iteration",
+        )
+        metrics = repeat_reliability_metrics(
+            successes,
+            trials,
+            confidence_level=confidence_level,
+            target_confidence=target_confidence,
+            rtt_factor=rtt_scale,
+            iterations=iteration_scale,
+            effort_per_iteration=effort_scale,
+        )
+        required_trials = required_trials_for_relative_error(
+            metrics.success_probability.estimate,
+            relative_error_threshold=relative_error_threshold,
+            confidence_level=confidence_level,
+            target_confidence=target_confidence,
+            method=required_trials_method,
+        )
+        reliable = _is_reliable(
+            trials,
+            required_trials,
+            metrics.r_c.relative_error,
+            relative_error_threshold,
+        )
+        record.update(
+            {
+                "successes": successes,
+                "trials": trials,
+                "success_rate": successes / trials if trials else math.nan,
+                "p_hat": metrics.success_probability.estimate,
+                "p_ci_lower": metrics.success_probability.lower,
+                "p_ci_upper": metrics.success_probability.upper,
+                "p_ci_half_width": metrics.success_probability.half_width,
+                "R99": metrics.r_c.estimate,
+                "R99_ci_lower": metrics.r_c.lower,
+                "R99_ci_upper": metrics.r_c.upper,
+                "RTT": metrics.rtt.estimate,
+                "RTT_ci_lower": metrics.rtt.lower,
+                "RTT_ci_upper": metrics.rtt.upper,
+                "CETS": metrics.cets.estimate,
+                "CETS_ci_lower": metrics.cets.lower,
+                "CETS_ci_upper": metrics.cets.upper,
+                "maximum_relative_error": metrics.r_c.relative_error,
+                "required_trials": required_trials,
+                "additional_trials_required": _additional_trials_required(
+                    trials,
+                    required_trials,
+                ),
+                "reliable": reliable,
+                "reliability_status": "reliable" if reliable else "needs_more_trials",
+                "confidence_level": confidence_level,
+                "target_confidence": target_confidence,
+                "relative_error_threshold": relative_error_threshold,
+                "rtt_factor": rtt_scale,
+                "iterations": iteration_scale,
+                "effort_per_iteration": effort_scale,
+            }
+        )
+        records.append(record)
+
+    report = (
+        pd.DataFrame.from_records(records)
+        if records
+        else pd.DataFrame(
+            columns=_repeat_reliability_report_columns(groups, comparison_cols)
+        )
+    )
+    if add_comparison_flags:
+        report = annotate_reliability_comparisons(
+            report,
+            comparison_cols=comparison_cols,
+            objective=comparison_objective,
+        )
+    return report
+
+
+def annotate_reliability_comparisons(
+    df: pd.DataFrame,
+    *,
+    comparison_cols: str | Sequence[str] | None = None,
+    estimate_col: str = "R99",
+    lower_col: str = "R99_ci_lower",
+    upper_col: str = "R99_ci_upper",
+    objective: str | int = "min",
+) -> pd.DataFrame:
+    """Flag point-estimate winners whose confidence intervals are unresolved.
+
+    The default objective is minimization because lower R99/RTT/CETS values are
+    better. For probability-like metrics, pass ``objective="max"`` and the
+    corresponding estimate/interval columns.
+    """
+
+    if not isinstance(df, pd.DataFrame):
+        raise TypeError("df must be a pandas DataFrame")
+
+    result = df.copy()
+    for flag_col in [
+        "best_point_estimate",
+        "ci_overlaps_best",
+        "statistically_unresolved",
+    ]:
+        result[flag_col] = False
+
+    if result.empty:
+        return result
+
+    groups = _coerce_column_list(comparison_cols)
+    _require_columns(result, [estimate_col, lower_col, upper_col, *groups])
+    direction = _normalize_direction(objective, "objective")
+
+    for _, group in _iter_groups(result, groups):
+        estimates = pd.to_numeric(group[estimate_col], errors="coerce")
+        valid_estimates = estimates.dropna()
+        if valid_estimates.empty:
+            continue
+        best_value = valid_estimates.min() if direction == "min" else valid_estimates.max()
+        best_indices = estimates[estimates == best_value].index
+        result.loc[best_indices, "best_point_estimate"] = True
+
+        if len(group) <= 1:
+            continue
+
+        best_intervals = [
+            _row_interval(result.loc[index], lower_col, upper_col)
+            for index in best_indices
+        ]
+        for index, row in group.iterrows():
+            interval = _row_interval(row, lower_col, upper_col)
+            if interval is None:
+                continue
+            if index in best_indices and len(best_indices) == 1:
+                unresolved = any(
+                    other_index != index
+                    and _intervals_overlap(
+                        interval,
+                        _row_interval(other_row, lower_col, upper_col),
+                    )
+                    for other_index, other_row in group.iterrows()
+                )
+            else:
+                unresolved = any(
+                    _intervals_overlap(interval, best_interval)
+                    for best_interval in best_intervals
+                )
+            result.loc[index, "ci_overlaps_best"] = unresolved
+            result.loc[index, "statistically_unresolved"] = unresolved
+
+    return result
+
+
+def _repeat_reliability_report_columns(
+    group_cols: Sequence[str],
+    comparison_cols: str | Sequence[str] | None,
+) -> list[str]:
+    columns = list(group_cols)
+    for column in _coerce_column_list(comparison_cols):
+        if column not in columns:
+            columns.append(column)
+    columns.extend(
+        [
+            "successes",
+            "trials",
+            "success_rate",
+            "p_hat",
+            "p_ci_lower",
+            "p_ci_upper",
+            "p_ci_half_width",
+            "R99",
+            "R99_ci_lower",
+            "R99_ci_upper",
+            "RTT",
+            "RTT_ci_lower",
+            "RTT_ci_upper",
+            "CETS",
+            "CETS_ci_lower",
+            "CETS_ci_upper",
+            "maximum_relative_error",
+            "required_trials",
+            "additional_trials_required",
+            "reliable",
+            "reliability_status",
+            "confidence_level",
+            "target_confidence",
+            "relative_error_threshold",
+            "rtt_factor",
+            "iterations",
+            "effort_per_iteration",
+        ]
+    )
+    return columns
+
+
 def required_repeats_for_probability_error(
     error_tolerance: float,
     confidence_fraction: float = DEFAULT_CONFIDENCE_FRACTION,
@@ -563,6 +846,293 @@ def required_trials_for_relative_error(
         target_confidence=target,
         confidence_fraction=confidence_fraction,
     )
+
+
+def _coerce_column_list(columns: str | Sequence[str] | None) -> list[str]:
+    if columns is None:
+        return []
+    if isinstance(columns, str):
+        return [columns]
+    return list(columns)
+
+
+def _require_columns(df: pd.DataFrame, columns: Sequence[str]) -> None:
+    missing = [column for column in columns if column not in df.columns]
+    if missing:
+        raise ValueError("missing required columns: {}".format(", ".join(missing)))
+
+
+def _iter_groups(df: pd.DataFrame, groups: Sequence[str]):
+    if not groups:
+        yield (), df
+        return
+
+    groupby_arg = groups[0] if len(groups) == 1 else list(groups)
+    for key, group in df.groupby(groupby_arg, dropna=False, sort=False):
+        if len(groups) == 1:
+            yield (key,), group
+        else:
+            yield key, group
+
+
+def _count_series(df: pd.DataFrame, count_col: str | None) -> pd.Series:
+    if count_col is None:
+        return pd.Series(1.0, index=df.index)
+
+    counts = pd.to_numeric(df[count_col], errors="coerce")
+    if counts.isna().any():
+        raise ValueError("count_col must contain numeric counts")
+    if (counts < 0).any():
+        raise ValueError("count_col must contain non-negative counts")
+    if not counts.apply(lambda value: float(value).is_integer()).all():
+        raise ValueError("count_col must contain integer counts")
+    return counts.astype(float)
+
+
+def _success_series(
+    df: pd.DataFrame,
+    *,
+    response_col: str | None,
+    success_col: str | None,
+    success_rule: str,
+    threshold: float | str | None,
+    response_dir: str | int,
+    target_value: float | str,
+    best_value: float | str | None,
+    random_value: float | str | None,
+    gap: float | None,
+    gap_is_percent: bool,
+    perf_ratio_col: str | None,
+) -> pd.Series:
+    if success_col is not None:
+        _require_columns(df, [success_col])
+        successes = df[success_col]
+        if successes.isna().any():
+            raise ValueError("success_col must not contain null values")
+        return successes.astype(bool)
+
+    rule = _canonical_success_rule(success_rule)
+    if rule == "perf_ratio":
+        metric_col = perf_ratio_col or response_col
+        metric = _required_metric_series(df, metric_col, "perf_ratio_col")
+        threshold_series = _required_numeric_series(df, threshold, "threshold")
+        return metric >= threshold_series
+
+    response = _required_metric_series(df, response_col, "response_col")
+    if rule == "min":
+        return response <= _required_numeric_series(df, threshold, "threshold")
+    if rule == "max":
+        return response >= _required_numeric_series(df, threshold, "threshold")
+    if rule == "absolute":
+        target = _numeric_series(df, target_value, "target_value")
+        return (response - target).abs() <= _required_numeric_series(
+            df,
+            threshold,
+            "threshold",
+        )
+    if rule in {"gap", "gap_min", "gap_max"}:
+        return _gap_success_series(
+            df,
+            response=response,
+            rule=rule,
+            response_dir=response_dir,
+            threshold=threshold,
+            best_value=best_value,
+            random_value=random_value,
+            gap=gap,
+            gap_is_percent=gap_is_percent,
+        )
+
+    raise ValueError("unsupported success_rule: {}".format(success_rule))
+
+
+def _gap_success_series(
+    df: pd.DataFrame,
+    *,
+    response: pd.Series,
+    rule: str,
+    response_dir: str | int,
+    threshold: float | str | None,
+    best_value: float | str | None,
+    random_value: float | str | None,
+    gap: float | None,
+    gap_is_percent: bool,
+) -> pd.Series:
+    direction = (
+        "min"
+        if rule == "gap_min"
+        else "max"
+        if rule == "gap_max"
+        else _normalize_direction(response_dir, "response_dir")
+    )
+    gap_value = gap if gap is not None else threshold
+    gap_series = _required_numeric_series(df, gap_value, "gap")
+    if gap_is_percent:
+        gap_series = gap_series / 100.0
+    if (gap_series < 0).any():
+        raise ValueError("gap must be non-negative")
+
+    best = _required_numeric_series(df, best_value, "best_value")
+    delta = gap_series * best.abs()
+    if random_value is not None:
+        random = _numeric_series(df, random_value, "random_value")
+        delta = gap_series * (random - best).abs()
+    return response <= best + delta if direction == "min" else response >= best - delta
+
+
+def _canonical_success_rule(success_rule: str) -> str:
+    if not isinstance(success_rule, str):
+        raise ValueError("success_rule must be a string")
+    rule = success_rule.lower().replace("-", "_").replace(" ", "_")
+    aliases = {
+        "min": "min",
+        "minimize": "min",
+        "minimization": "min",
+        "max": "max",
+        "maximize": "max",
+        "maximization": "max",
+        "absolute": "absolute",
+        "abs": "absolute",
+        "absolute_threshold": "absolute",
+        "gap": "gap",
+        "gap_min": "gap_min",
+        "min_gap": "gap_min",
+        "gap_minimization": "gap_min",
+        "gap_max": "gap_max",
+        "max_gap": "gap_max",
+        "gap_maximization": "gap_max",
+        "perf_ratio": "perf_ratio",
+        "perfratio": "perf_ratio",
+        "performance_ratio": "perf_ratio",
+    }
+    if rule not in aliases:
+        raise ValueError("unsupported success_rule: {}".format(success_rule))
+    return aliases[rule]
+
+
+def _required_metric_series(
+    df: pd.DataFrame,
+    column: str | None,
+    name: str,
+) -> pd.Series:
+    if column is None:
+        raise ValueError("{} is required".format(name))
+    _require_columns(df, [column])
+    return _numeric_series(df, column, name)
+
+
+def _required_numeric_series(
+    df: pd.DataFrame,
+    value: float | str | None,
+    name: str,
+) -> pd.Series:
+    if value is None:
+        raise ValueError("{} is required".format(name))
+    return _numeric_series(df, value, name)
+
+
+def _numeric_series(
+    df: pd.DataFrame,
+    value: float | str,
+    name: str,
+) -> pd.Series:
+    if isinstance(value, str) and value in df.columns:
+        series = pd.to_numeric(df[value], errors="coerce")
+    else:
+        try:
+            scalar = float(value)
+        except (TypeError, ValueError) as exc:
+            raise ValueError("{} must be numeric or a column name".format(name)) from exc
+        series = pd.Series(scalar, index=df.index)
+
+    if series.isna().any():
+        raise ValueError("{} must contain numeric values".format(name))
+    return series.astype(float)
+
+
+def _weighted_group_value(
+    group: pd.DataFrame,
+    value: float | str,
+    *,
+    weight_col: str,
+    name: str,
+) -> float:
+    values = _numeric_series(group, value, name)
+    if (values < 0).any():
+        raise ValueError("{} must be non-negative".format(name))
+    weights = group[weight_col].astype(float)
+    total_weight = weights.sum()
+    if total_weight == 0:
+        return float(values.mean())
+    return float((values * weights).sum() / total_weight)
+
+
+def _integer_count(value: float, name: str) -> int:
+    if not math.isfinite(value) or value < 0:
+        raise ValueError("{} must be a non-negative finite count".format(name))
+    rounded = round(value)
+    if not math.isclose(value, rounded, rel_tol=0.0, abs_tol=1e-9):
+        raise ValueError("{} must be an integer count".format(name))
+    return int(rounded)
+
+
+def _additional_trials_required(trials: int, required_trials: int | float) -> int | float:
+    if math.isinf(required_trials):
+        return math.inf
+    return max(0, math.ceil(required_trials - trials))
+
+
+def _is_reliable(
+    trials: int,
+    required_trials: int | float,
+    relative_error: float,
+    relative_error_threshold: float,
+) -> bool:
+    return (
+        math.isfinite(required_trials)
+        and math.isfinite(relative_error)
+        and trials >= required_trials
+        and relative_error <= relative_error_threshold
+    )
+
+
+def _normalize_direction(value: str | int, name: str) -> str:
+    if value == -1:
+        return "min"
+    if value == 1:
+        return "max"
+    if isinstance(value, str):
+        normalized = value.lower()
+        if normalized in {"min", "minimize", "minimization"}:
+            return "min"
+        if normalized in {"max", "maximize", "maximization"}:
+            return "max"
+    raise ValueError("{} must be 'min', 'max', -1, or 1".format(name))
+
+
+def _row_interval(
+    row: pd.Series,
+    lower_col: str,
+    upper_col: str,
+) -> tuple[float, float] | None:
+    lower = row[lower_col]
+    upper = row[upper_col]
+    if pd.isna(lower) or pd.isna(upper):
+        return None
+    lower = float(lower)
+    upper = float(upper)
+    if lower > upper:
+        raise ValueError("interval lower bound must be <= upper bound")
+    return lower, upper
+
+
+def _intervals_overlap(
+    first: tuple[float, float] | None,
+    second: tuple[float, float] | None,
+) -> bool:
+    if first is None or second is None:
+        return False
+    return first[0] <= second[1] and second[0] <= first[1]
 
 
 def _compute_agresti_coull_interval(

--- a/src/stochastic_benchmark.py
+++ b/src/stochastic_benchmark.py
@@ -402,7 +402,18 @@ class stochastic_benchmark:
                 self.bs_results = bs_results
 
     def run_RepeatReliability(self, df=None, **kwargs):
-        """Create a passive repeat-reliability report from existing observations."""
+        """Create a passive repeat-reliability report from existing observations.
+
+        Parameters are forwarded to
+        :func:`repeat_reliability.repeat_reliability_report`. If ``df`` is not
+        provided, the method uses the first populated DataFrame among
+        ``raw_data``, ``bs_results``, and ``interp_results``. If ``group_cols``
+        is omitted, observations are grouped by ``parameter_names`` plus
+        ``instance_cols`` so the report can be joined back to the benchmark
+        summaries on those columns. For accepted input shapes, success rules,
+        count-column semantics, and output columns, see
+        ``docs/passive_repeat_reliability_reports.md``.
+        """
 
         if df is None:
             if hasattr(self, "raw_data") and isinstance(self.raw_data, pd.DataFrame):

--- a/src/stochastic_benchmark.py
+++ b/src/stochastic_benchmark.py
@@ -13,6 +13,7 @@ import df_utils
 import interpolate
 import plotting as plotting_module
 from plotting import *
+import repeat_reliability
 import stats
 import success_metrics
 import training
@@ -399,6 +400,31 @@ class stochastic_benchmark:
                 self.bs_results = pd.concat(bs_results, ignore_index=True)
             elif isinstance(bs_results[0], str):
                 self.bs_results = bs_results
+
+    def run_RepeatReliability(self, df=None, **kwargs):
+        """Create a passive repeat-reliability report from existing observations."""
+
+        if df is None:
+            if hasattr(self, "raw_data") and isinstance(self.raw_data, pd.DataFrame):
+                df = self.raw_data
+            elif isinstance(self.bs_results, pd.DataFrame):
+                df = self.bs_results
+            elif isinstance(self.interp_results, pd.DataFrame):
+                df = self.interp_results
+            else:
+                raise ValueError(
+                    "df is required unless raw_data, bs_results, or interp_results "
+                    "is already populated as a DataFrame"
+                )
+
+        if "group_cols" not in kwargs or kwargs["group_cols"] is None:
+            kwargs["group_cols"] = self.parameter_names + self.instance_cols
+
+        self.repeat_reliability = repeat_reliability.repeat_reliability_report(
+            df,
+            **kwargs,
+        )
+        return self.repeat_reliability
 
     def run_Interpolate(self, iParams):
         if self.interp_results is not None:

--- a/tests/test_repeat_reliability.py
+++ b/tests/test_repeat_reliability.py
@@ -239,10 +239,13 @@ def test_issue_74_report_supports_grouped_run_level_min_thresholds():
     assert report.loc["alpha", "successes"] == 8
     assert report.loc["alpha", "trials"] == 10
     assert report.loc["alpha", "success_rate"] == pytest.approx(0.8)
+    assert report.loc["alpha", "p_hat"] == pytest.approx(0.8)
+    assert report.loc["alpha", "adjusted_p_hat"] != pytest.approx(0.8)
     assert report.loc["alpha", "p_hat"] > report.loc["beta", "p_hat"]
-    assert report.loc["alpha", "R99"] < report.loc["beta", "R99"]
-    assert report.loc["alpha", "RTT"] == pytest.approx(report.loc["alpha", "R99"] * 2.0)
-    assert report.loc["alpha", "CETS"] == pytest.approx(report.loc["alpha", "R99"] * 25.0)
+    assert report.loc["alpha", "R_c"] < report.loc["beta", "R_c"]
+    assert report.loc["alpha", "R99"] == pytest.approx(report.loc["alpha", "R_c"])
+    assert report.loc["alpha", "RTT"] == pytest.approx(report.loc["alpha", "R_c"] * 2.0)
+    assert report.loc["alpha", "CETS"] == pytest.approx(report.loc["alpha", "R_c"] * 25.0)
     assert {"best_point_estimate", "ci_overlaps_best", "statistically_unresolved"} <= set(report.columns)
 
 
@@ -268,7 +271,7 @@ def test_issue_74_report_supports_count_column_perf_ratio_data():
     assert report.loc["alpha", "trials"] == 100
     assert report.loc["beta", "successes"] == 70
     assert report.loc["beta", "trials"] == 100
-    assert report.loc["alpha", "R99"] < report.loc["beta", "R99"]
+    assert report.loc["alpha", "R_c"] < report.loc["beta", "R_c"]
 
 
 @pytest.mark.parametrize(
@@ -319,9 +322,9 @@ def test_issue_74_comparison_flags_mark_unresolved_intervals():
         {
             "budget": [10, 10, 10],
             "candidate": ["alpha", "beta", "gamma"],
-            "R99": [10.0, 11.0, 20.0],
-            "R99_ci_lower": [8.0, 9.0, 18.0],
-            "R99_ci_upper": [12.0, 13.0, 22.0],
+            "R_c": [10.0, 11.0, 20.0],
+            "R_c_ci_lower": [8.0, 9.0, 18.0],
+            "R_c_ci_upper": [12.0, 13.0, 22.0],
         }
     )
 
@@ -346,11 +349,11 @@ def test_issue_74_empty_report_keeps_joinable_columns_and_flags():
     )
 
     assert report.empty
-    assert {"solver", "budget", "successes", "R99", "best_point_estimate"} <= set(report.columns)
+    assert {"solver", "budget", "successes", "R_c", "R99", "best_point_estimate"} <= set(report.columns)
 
 
 def test_issue_74_report_accepts_success_column_and_rejects_null_successes():
-    df = pd.DataFrame({"solver": ["alpha", "alpha"], "ok": [True, False], "n": [2, 3]})
+    df = pd.DataFrame({"solver": ["alpha", "alpha"], "ok": ["true", "0"], "n": [2, 3]})
 
     report = repeat_reliability_report(
         df,
@@ -366,6 +369,16 @@ def test_issue_74_report_accepts_success_column_and_rejects_null_successes():
     with pytest.raises(ValueError, match="success_col"):
         repeat_reliability_report(
             pd.DataFrame({"ok": [True, None]}),
+            success_col="ok",
+        )
+    with pytest.raises(ValueError, match="success_col"):
+        repeat_reliability_report(
+            pd.DataFrame({"ok": ["False", "not sure"]}),
+            success_col="ok",
+        )
+    with pytest.raises(ValueError, match="success_col"):
+        repeat_reliability_report(
+            pd.DataFrame({"ok": [0, 2]}),
             success_col="ok",
         )
 
@@ -475,6 +488,51 @@ def test_issue_74_zero_count_rows_produce_empty_trial_report():
     assert report.loc[0, "rtt_factor"] == pytest.approx(3.0)
 
 
+def test_issue_74_cets_uses_count_weighted_per_row_product():
+    df = pd.DataFrame(
+        {
+            "response": [1.0, 1.0],
+            "iterations": [1.0, 100.0],
+            "effort": [100.0, 1.0],
+            "n": [1, 3],
+        }
+    )
+
+    report = repeat_reliability_report(
+        df,
+        response_col="response",
+        success_rule="min",
+        threshold=1.0,
+        count_col="n",
+        iterations="iterations",
+        effort_per_iteration="effort",
+        add_comparison_flags=False,
+    )
+
+    assert report.loc[0, "iterations"] == pytest.approx(75.25)
+    assert report.loc[0, "effort_per_iteration"] == pytest.approx(25.75)
+    assert report.loc[0, "cets_factor"] == pytest.approx(100.0)
+    assert report.loc[0, "CETS"] == pytest.approx(report.loc[0, "R_c"] * 100.0)
+
+
+def test_issue_74_non_default_target_uses_neutral_and_target_specific_columns():
+    df = pd.DataFrame({"response": [1.0, 2.0, 3.0]})
+
+    report = repeat_reliability_report(
+        df,
+        response_col="response",
+        success_rule="min",
+        threshold=2.0,
+        target_confidence=0.95,
+        add_comparison_flags=False,
+    )
+
+    assert "R_c" in report.columns
+    assert "R95" in report.columns
+    assert "R99" not in report.columns
+    assert report.loc[0, "R95"] == pytest.approx(report.loc[0, "R_c"])
+
+
 def test_issue_74_comparison_flags_handle_max_objective_and_invalid_intervals():
     df = pd.DataFrame(
         {
@@ -510,15 +568,15 @@ def test_issue_74_comparison_flags_handle_max_objective_and_invalid_intervals():
         annotate_reliability_comparisons(
             pd.DataFrame(
                 {
-                    "R99": [1.0, 2.0],
-                    "R99_ci_lower": [2.0, 1.5],
-                    "R99_ci_upper": [1.0, 2.5],
+                    "R_c": [1.0, 2.0],
+                    "R_c_ci_lower": [2.0, 1.5],
+                    "R_c_ci_upper": [1.0, 2.5],
                 }
             )
         )
     with pytest.raises(ValueError, match="objective"):
         annotate_reliability_comparisons(
-            pd.DataFrame({"R99": [1.0], "R99_ci_lower": [0.9], "R99_ci_upper": [1.1]}),
+            pd.DataFrame({"R_c": [1.0], "R_c_ci_lower": [0.9], "R_c_ci_upper": [1.1]}),
             objective="better",
         )
     with pytest.raises(TypeError, match="pandas DataFrame"):
@@ -526,7 +584,7 @@ def test_issue_74_comparison_flags_handle_max_objective_and_invalid_intervals():
 
 
 def test_issue_74_comparison_flags_skip_all_nan_estimates():
-    df = pd.DataFrame({"R99": [np.nan], "R99_ci_lower": [0.0], "R99_ci_upper": [1.0]})
+    df = pd.DataFrame({"R_c": [np.nan], "R_c_ci_lower": [0.0], "R_c_ci_upper": [1.0]})
 
     flagged = annotate_reliability_comparisons(df, objective=1)
 

--- a/tests/test_repeat_reliability.py
+++ b/tests/test_repeat_reliability.py
@@ -333,6 +333,207 @@ def test_issue_74_comparison_flags_mark_unresolved_intervals():
     assert not flagged.loc["gamma", "statistically_unresolved"]
 
 
+def test_issue_74_empty_report_keeps_joinable_columns_and_flags():
+    df = pd.DataFrame({"solver": [], "value": []})
+
+    report = repeat_reliability_report(
+        df,
+        group_cols="solver",
+        response_col="value",
+        success_rule="min",
+        threshold=1.0,
+        comparison_cols="budget",
+    )
+
+    assert report.empty
+    assert {"solver", "budget", "successes", "R99", "best_point_estimate"} <= set(report.columns)
+
+
+def test_issue_74_report_accepts_success_column_and_rejects_null_successes():
+    df = pd.DataFrame({"solver": ["alpha", "alpha"], "ok": [True, False], "n": [2, 3]})
+
+    report = repeat_reliability_report(
+        df,
+        group_cols="solver",
+        success_col="ok",
+        count_col="n",
+        add_comparison_flags=False,
+    )
+
+    assert report.loc[0, "successes"] == 2
+    assert report.loc[0, "trials"] == 5
+
+    with pytest.raises(ValueError, match="success_col"):
+        repeat_reliability_report(
+            pd.DataFrame({"ok": [True, None]}),
+            success_col="ok",
+        )
+
+
+@pytest.mark.parametrize(
+    "counts,match",
+    [
+        (["bad"], "numeric"),
+        ([-1], "non-negative"),
+        ([1.5], "integer"),
+    ],
+)
+def test_issue_74_report_rejects_invalid_count_columns(counts, match):
+    df = pd.DataFrame({"value": [1.0], "n": counts})
+
+    with pytest.raises(ValueError, match=match):
+        repeat_reliability_report(
+            df,
+            response_col="value",
+            success_rule="min",
+            threshold=1.0,
+            count_col="n",
+        )
+
+
+def test_issue_74_gap_rule_supports_percent_random_reference_and_response_dir():
+    df = pd.DataFrame(
+        {
+            "response": [10.0, 11.0, 12.0],
+            "best": [10.0, 10.0, 10.0],
+            "random": [20.0, 20.0, 20.0],
+        }
+    )
+
+    report = repeat_reliability_report(
+        df,
+        response_col="response",
+        success_rule="gap",
+        response_dir=-1,
+        best_value="best",
+        random_value="random",
+        gap=10.0,
+        gap_is_percent=True,
+    )
+
+    assert report.loc[0, "successes"] == 2
+
+
+def test_issue_74_report_validation_errors_cover_public_api_edges():
+    df = pd.DataFrame({"value": [1.0]})
+
+    with pytest.raises(TypeError, match="pandas DataFrame"):
+        repeat_reliability_report(object())
+    with pytest.raises(ValueError, match="missing required columns"):
+        repeat_reliability_report(df, group_cols="missing", response_col="value", threshold=1.0)
+    with pytest.raises(ValueError, match="success_rule"):
+        repeat_reliability_report(df, response_col="value", success_rule=object(), threshold=1.0)
+    with pytest.raises(ValueError, match="unsupported success_rule"):
+        repeat_reliability_report(df, response_col="value", success_rule="unknown", threshold=1.0)
+    with pytest.raises(ValueError, match="response_col"):
+        repeat_reliability_report(df, success_rule="min", threshold=1.0)
+    with pytest.raises(ValueError, match="threshold"):
+        repeat_reliability_report(df, response_col="value", success_rule="min")
+    with pytest.raises(ValueError, match="threshold"):
+        repeat_reliability_report(df, response_col="value", success_rule="min", threshold="not-a-number")
+    with pytest.raises(ValueError, match="threshold"):
+        repeat_reliability_report(
+            pd.DataFrame({"value": [1.0], "threshold": [np.nan]}),
+            response_col="value",
+            success_rule="min",
+            threshold="threshold",
+        )
+    with pytest.raises(ValueError, match="gap"):
+        repeat_reliability_report(
+            df,
+            response_col="value",
+            success_rule="gap_min",
+            best_value=1.0,
+            gap=-0.1,
+        )
+    with pytest.raises(ValueError, match="rtt_factor"):
+        repeat_reliability_report(
+            df,
+            response_col="value",
+            success_rule="min",
+            threshold=1.0,
+            rtt_factor=-1.0,
+        )
+
+
+def test_issue_74_zero_count_rows_produce_empty_trial_report():
+    df = pd.DataFrame({"value": [1.0], "n": [0], "runtime": [3.0]})
+
+    report = repeat_reliability_report(
+        df,
+        response_col="value",
+        success_rule="min",
+        threshold=1.0,
+        count_col="n",
+        rtt_factor="runtime",
+        add_comparison_flags=False,
+    )
+
+    assert report.loc[0, "successes"] == 0
+    assert report.loc[0, "trials"] == 0
+    assert math.isnan(report.loc[0, "success_rate"])
+    assert report.loc[0, "rtt_factor"] == pytest.approx(3.0)
+
+
+def test_issue_74_comparison_flags_handle_max_objective_and_invalid_intervals():
+    df = pd.DataFrame(
+        {
+            "candidate": ["alpha", "beta", "gamma"],
+            "p_hat": [0.8, 0.7, np.nan],
+            "p_ci_lower": [0.7, 0.6, np.nan],
+            "p_ci_upper": [0.9, 0.69, np.nan],
+        }
+    )
+
+    flagged = annotate_reliability_comparisons(
+        df,
+        estimate_col="p_hat",
+        lower_col="p_ci_lower",
+        upper_col="p_ci_upper",
+        objective="max",
+    ).set_index("candidate")
+
+    assert flagged.loc["alpha", "best_point_estimate"]
+    assert not flagged.loc["beta", "statistically_unresolved"]
+    assert not flagged.loc["gamma", "ci_overlaps_best"]
+
+    empty = annotate_reliability_comparisons(
+        df.iloc[0:0],
+        estimate_col="p_hat",
+        lower_col="p_ci_lower",
+        upper_col="p_ci_upper",
+        objective="max",
+    )
+    assert empty.empty
+
+    with pytest.raises(ValueError, match="interval lower"):
+        annotate_reliability_comparisons(
+            pd.DataFrame(
+                {
+                    "R99": [1.0, 2.0],
+                    "R99_ci_lower": [2.0, 1.5],
+                    "R99_ci_upper": [1.0, 2.5],
+                }
+            )
+        )
+    with pytest.raises(ValueError, match="objective"):
+        annotate_reliability_comparisons(
+            pd.DataFrame({"R99": [1.0], "R99_ci_lower": [0.9], "R99_ci_upper": [1.1]}),
+            objective="better",
+        )
+    with pytest.raises(TypeError, match="pandas DataFrame"):
+        annotate_reliability_comparisons(object())
+
+
+def test_issue_74_comparison_flags_skip_all_nan_estimates():
+    df = pd.DataFrame({"R99": [np.nan], "R99_ci_lower": [0.0], "R99_ci_upper": [1.0]})
+
+    flagged = annotate_reliability_comparisons(df, objective=1)
+
+    assert not flagged.loc[0, "best_point_estimate"]
+    assert not flagged.loc[0, "statistically_unresolved"]
+
+
 @pytest.mark.parametrize(
     "call",
     [

--- a/tests/test_repeat_reliability.py
+++ b/tests/test_repeat_reliability.py
@@ -13,10 +13,12 @@ from repeat_reliability import (
     cets_from_repeat_count,
     maximum_relative_error,
     normal_critical_value,
+    annotate_reliability_comparisons,
     propagate_success_probability_interval,
     relative_repeats_error,
     repeat_count,
     repeat_count_interval,
+    repeat_reliability_report,
     repeat_reliability_metrics,
     repeats_to_solution,
     required_repeats_exact,
@@ -211,6 +213,124 @@ def test_issue_73_required_trials_wrapper_boundaries_and_methods():
         required_trials_for_relative_error(1.0, target_confidence=1.0)
     with pytest.raises(ValueError):
         required_trials_for_relative_error(0.5, method="bound", target_confidence=1.0)
+
+
+def test_issue_74_report_supports_grouped_run_level_min_thresholds():
+    df = pd.DataFrame(
+        {
+            "solver": ["alpha"] * 10 + ["beta"] * 10,
+            "energy": [0.5] * 8 + [2.0] * 2 + [0.5] * 5 + [2.0] * 5,
+            "runtime": [2.0] * 20,
+            "iterations": [50] * 20,
+        }
+    )
+
+    report = repeat_reliability_report(
+        df,
+        group_cols="solver",
+        response_col="energy",
+        success_rule="min",
+        threshold=1.0,
+        rtt_factor="runtime",
+        iterations="iterations",
+        effort_per_iteration=0.5,
+    ).set_index("solver")
+
+    assert report.loc["alpha", "successes"] == 8
+    assert report.loc["alpha", "trials"] == 10
+    assert report.loc["alpha", "success_rate"] == pytest.approx(0.8)
+    assert report.loc["alpha", "p_hat"] > report.loc["beta", "p_hat"]
+    assert report.loc["alpha", "R99"] < report.loc["beta", "R99"]
+    assert report.loc["alpha", "RTT"] == pytest.approx(report.loc["alpha", "R99"] * 2.0)
+    assert report.loc["alpha", "CETS"] == pytest.approx(report.loc["alpha", "R99"] * 25.0)
+    assert {"best_point_estimate", "ci_overlaps_best", "statistically_unresolved"} <= set(report.columns)
+
+
+def test_issue_74_report_supports_count_column_perf_ratio_data():
+    df = pd.DataFrame(
+        {
+            "solver": ["alpha", "alpha", "beta", "beta"],
+            "PerfRatio": [0.95, 0.50, 0.90, 0.10],
+            "n": [90, 10, 70, 30],
+        }
+    )
+
+    report = repeat_reliability_report(
+        df,
+        group_cols="solver",
+        response_col="PerfRatio",
+        success_rule="PerfRatio",
+        threshold=0.8,
+        count_col="n",
+    ).set_index("solver")
+
+    assert report.loc["alpha", "successes"] == 90
+    assert report.loc["alpha", "trials"] == 100
+    assert report.loc["beta", "successes"] == 70
+    assert report.loc["beta", "trials"] == 100
+    assert report.loc["alpha", "R99"] < report.loc["beta", "R99"]
+
+
+@pytest.mark.parametrize(
+    "kwargs,expected_successes",
+    [
+        ({"response_col": "value", "success_rule": "min", "threshold": 1.0}, 2),
+        ({"response_col": "value", "success_rule": "max", "threshold": 1.0}, 2),
+        (
+            {
+                "response_col": "value",
+                "success_rule": "absolute",
+                "threshold": 0.11,
+                "target_value": 1.0,
+            },
+            2,
+        ),
+        (
+            {
+                "response_col": "value",
+                "success_rule": "gap_min",
+                "best_value": 1.0,
+                "gap": 0.10,
+            },
+            2,
+        ),
+        (
+            {
+                "response_col": "value",
+                "success_rule": "gap_max",
+                "best_value": 1.0,
+                "gap": 0.05,
+            },
+            2,
+        ),
+    ],
+)
+def test_issue_74_success_rule_variants(kwargs, expected_successes):
+    df = pd.DataFrame({"value": [0.9, 1.0, 1.2]})
+
+    report = repeat_reliability_report(df, **kwargs)
+
+    assert report.loc[0, "successes"] == expected_successes
+    assert report.loc[0, "trials"] == 3
+
+
+def test_issue_74_comparison_flags_mark_unresolved_intervals():
+    df = pd.DataFrame(
+        {
+            "budget": [10, 10, 10],
+            "candidate": ["alpha", "beta", "gamma"],
+            "R99": [10.0, 11.0, 20.0],
+            "R99_ci_lower": [8.0, 9.0, 18.0],
+            "R99_ci_upper": [12.0, 13.0, 22.0],
+        }
+    )
+
+    flagged = annotate_reliability_comparisons(df, comparison_cols="budget").set_index("candidate")
+
+    assert flagged.loc["alpha", "best_point_estimate"]
+    assert flagged.loc["alpha", "statistically_unresolved"]
+    assert flagged.loc["beta", "ci_overlaps_best"]
+    assert not flagged.loc["gamma", "statistically_unresolved"]
 
 
 @pytest.mark.parametrize(

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -65,6 +65,8 @@ class TestImports:
         assert hasattr(repeat_reliability, 'repeat_count')
         assert hasattr(repeat_reliability, 'repeats_to_solution')
         assert hasattr(repeat_reliability, 'required_trials_for_relative_error')
+        assert hasattr(repeat_reliability, 'repeat_reliability_report')
+        assert hasattr(repeat_reliability, 'annotate_reliability_comparisons')
     
     def test_import_training(self):
         """Test importing training module."""

--- a/tests/test_stochastic_benchmark.py
+++ b/tests/test_stochastic_benchmark.py
@@ -83,6 +83,35 @@ def test_run_repeat_reliability_uses_existing_observations_and_default_groups(tm
     assert report.loc[0, "trials"] == 3
 
 
+@pytest.mark.parametrize("attribute", ["raw_data", "bs_results", "interp_results"])
+def test_run_repeat_reliability_uses_populated_dataframe_sources(tmp_path, attribute):
+    sb = _make_benchmark(tmp_path)
+    df = pd.DataFrame(
+        {
+            "instance": [1, 1],
+            "param1": [0.1, 0.1],
+            "response": [0.2, 1.5],
+        }
+    )
+    setattr(sb, attribute, df)
+
+    report = sb.run_RepeatReliability(
+        response_col="response",
+        success_rule="min",
+        threshold=0.5,
+    )
+
+    assert report.loc[0, "successes"] == 1
+    assert report.loc[0, "trials"] == 2
+
+
+def test_run_repeat_reliability_requires_existing_dataframe_source(tmp_path):
+    sb = _make_benchmark(tmp_path)
+
+    with pytest.raises(ValueError, match="df is required"):
+        sb.run_RepeatReliability(response_col="response", threshold=0.5)
+
+
 def test_run_bootstrap_non_reduce_uses_existing_raw_data_and_persists(tmp_path, monkeypatch):
     sb = _make_benchmark(tmp_path, reduce_mem=False, recover=False)
     sb.raw_data = pd.DataFrame({

--- a/tests/test_stochastic_benchmark.py
+++ b/tests/test_stochastic_benchmark.py
@@ -59,6 +59,30 @@ def test_set_bootstrap_accepts_paths_dataframes_and_lists(tmp_path):
     assert sb.bs_results == [str(pickle_path)]
 
 
+def test_run_repeat_reliability_uses_existing_observations_and_default_groups(tmp_path):
+    sb = _make_benchmark(tmp_path)
+    df = pd.DataFrame(
+        {
+            "instance": [1, 1, 1],
+            "param1": [0.1, 0.1, 0.1],
+            "response": [0.2, 0.4, 1.5],
+        }
+    )
+
+    report = sb.run_RepeatReliability(
+        df,
+        response_col="response",
+        success_rule="min",
+        threshold=0.5,
+    )
+
+    assert sb.repeat_reliability is report
+    assert report.loc[0, "instance"] == 1
+    assert report.loc[0, "param1"] == pytest.approx(0.1)
+    assert report.loc[0, "successes"] == 2
+    assert report.loc[0, "trials"] == 3
+
+
 def test_run_bootstrap_non_reduce_uses_existing_raw_data_and_persists(tmp_path, monkeypatch):
     sb = _make_benchmark(tmp_path, reduce_mem=False, recover=False)
     sb.raw_data = pd.DataFrame({


### PR DESCRIPTION
## Summary

- Add `repeat_reliability_report` for passive dataframe reliability reports over existing observations.
- Support grouped run-level rows, optional count-column rows, minimization/maximization/absolute/gap/PerfRatio success rules, R99/RTT/CETS intervals, required trials, reliability status, and unresolved-comparison flags.
- Add `stochastic_benchmark.run_RepeatReliability(...)` as an opt-in wrapper without changing existing Window Sticker defaults.

## Tests run

- `python -m pytest tests/test_repeat_reliability.py tests/test_stochastic_benchmark.py::test_run_repeat_reliability_uses_existing_observations_and_default_groups tests/test_smoke.py::TestImports::test_import_repeat_reliability`
  - Result: passed, 85 tests.
- `python -m pytest tests/test_repeat_reliability.py tests/test_stochastic_benchmark.py::test_run_repeat_reliability_uses_existing_observations_and_default_groups tests/test_stochastic_benchmark.py::test_run_repeat_reliability_uses_populated_dataframe_sources tests/test_stochastic_benchmark.py::test_run_repeat_reliability_requires_existing_dataframe_source`
  - Result: passed, 98 tests.
- `python -m pytest tests/test_repeat_reliability.py`
  - Result: passed, 83 tests before the follow-up coverage additions.
- `python -m pytest tests/test_repeat_reliability.py tests/test_stochastic_benchmark.py --cov=src --cov-report=term-missing --cov-fail-under=0`
  - Result: passed, 112 tests; `src/repeat_reliability.py` reported 98% coverage. Overall coverage is low for this partial test selection, as expected.
- `python run_tests.py unit`
  - Result: passed, 399 tests, 12 warnings.
- `python run_tests.py integration`
  - Result: passed, 11 tests.
- `flake8 src --count --select=E9,F63,F7,F82 --show-source --statistics`
  - Result: passed, output `0`.
- `flake8 src --count --exit-zero --max-complexity=10 --max-line-length=120 --statistics`
  - Result: completed with exit code 0; reported existing advisory warnings in unrelated modules.
- `flake8 src/repeat_reliability.py --count --exit-zero --max-complexity=10 --max-line-length=120 --statistics`
  - Result: passed, output `0`.
- `git diff --check`
  - Result: passed.

## Notes

- The full tutorial notebook smoke job was not run locally because this change does not touch examples or notebook execution paths; CI will run that job.
- A targeted coverage run without `--cov-fail-under=0` failed because the repository-wide 80% threshold was applied to a partial two-file test selection; the follow-up targeted coverage command above was run with fail-under disabled to inspect changed-module coverage.

Closes #74
