### PR TITLE
Document repeat reliability methodology

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Details of the implementation and an illustrative example for Wishart instances 
 ## Table of Contents
 
 - [Background](#background)
+- [Methodology Reliability](#methodology-reliability)
 - [Installation](#installation)
 - [Examples](#examples)
 - [Documentation](#documentation)
@@ -39,6 +40,51 @@ The current package implements the following functionality:
 - Perform an exploration-exploitation parameter setting strategy, where the fraction of the allocated resources used in the exploration round is optimized. The exploration procedure is implemented as a random search in the seen parameter settings or a Bayesian-based method known as the tree of parzen and implemented in the package [Hyperopt](https://hyperopt.github.io/hyperopt/) when generation dependencies are installed.
 - Plot the Window sticker, comparing the performance curves corresponding to the virtual best, recommended parameters, and exploration-exploitation parameter setting strategies.
 - Plots the values of the parameters and their best values with respect to the resource considered, a plot we call the Strategy plot. These plots can show the actual solver parameter values or the meta-parameters associated with parameter-setting strategies.
+
+## Methodology Reliability
+
+The Window Sticker workflow combines two different uncertainty questions that
+should be interpreted separately. The cross-instance Window Sticker uncertainty
+comes from train/test splits, interpolation, aggregation, and bootstrap
+resampling across a problem family. It answers how a parameter-setting strategy
+is expected to perform on unseen instances from that family. Per-instance
+repeat-count reliability asks whether each solver, parameter setting, and
+resource level has enough repeated stochastic runs to support its own success
+probability, repeat count, and time-to-solution estimates.
+
+Repeat reliability follows Noori et al. 2026:
+
+Noori, Moslem, Elisabetta Valiante, Ignacio Rozada, Thomas Van Vaerenbergh, and
+Masoud Mohseni. "Statistical analysis for per-instance evaluation of stochastic
+optimizers: Avoiding unreliable conclusions." Physical Review Applied 25, no. 3
+(2026): 034081.
+
+The analytic guarantees implemented here apply to Bernoulli success events and
+metrics derived from their success probabilities: `R_c`, RTT/TTS, CETS, and
+thresholded continuous metrics. For example, a continuous energy, Response, or
+PerfRatio value can be analyzed with repeat reliability only after the workflow
+defines a threshold that turns each run into success or failure.
+
+The original Window Sticker bootstrap remains the uncertainty model for
+continuous Response curves and for continuous PerfRatio curves that are not
+converted to success thresholds. Those bootstrap intervals are useful for
+cross-instance benchmarking, but they are not a substitute for the analytic
+repeat-count checks above.
+
+Repeat reliability addresses several methodology criticisms directly:
+
+| Criticism | Documentation and package response |
+| --- | --- |
+| Repeat-count sufficiency | Report `required_trials`, `additional_trials_required`, `reliable`, and `reliability_status` so users can tell whether more stochastic runs are needed. |
+| Bootstrap-only uncertainty | Keep bootstrap intervals for cross-instance continuous curves, and use analytic Bernoulli intervals for per-instance success probabilities and derived repeat-count metrics. |
+| Noisy HPO choices | Surface repeat reliability before treating a parameter choice as stable, especially when success rates are small or intervals are wide. |
+| CI-overlap ambiguity | Flag `ci_overlaps_best` and `statistically_unresolved` comparisons instead of implying that overlapping intervals identify a clear winner. |
+| Virtual-best optimism | Document virtual best as an optimistic, unattainable reference and pair it with reliability checks when judging whether observed gaps are meaningful. |
+
+Use [docs/passive_repeat_reliability_reports.md](docs/passive_repeat_reliability_reports.md)
+to add passive repeat-reliability reports to existing benchmark data. Use
+[docs/noori_repeat_reliability_validation.md](docs/noori_repeat_reliability_validation.md)
+for the equation map and validation boundaries.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,9 @@
 
 Repository for Stochastic Optimization Solvers Benchmark implementation of the Window Sticker framework.
 
-The benchmarking approach is described in this [preprint](https://arxiv.org/abs/2402.10255) titled: *Benchmarking the Operation of Quantum Heuristics and Ising Machines: Scoring Parameter Setting Strategies on Optimization Applications*.
+The benchmarking approach is described in
+[*Benchmarking the Operation of Quantum Heuristics and Ising Machines: Scoring Parameter Setting Strategies on Optimization Applications*](https://link.springer.com/article/10.1007/s42484-025-00311-2),
+with the [arXiv preprint](https://arxiv.org/abs/2402.10255) also available.
 
 Details of the implementation and an illustrative example for Wishart instances found [here](examples/wishart_n_50_alpha_0.5/wishart_n_50_alpha_0.50.ipynb) are given in this [document](stochastic-benchmarking-notes.pdf).
 
@@ -15,6 +17,7 @@ Details of the implementation and an illustrative example for Wishart instances 
 
 - [Background](#background)
 - [Methodology Reliability](#methodology-reliability)
+- [References](#references)
 - [Installation](#installation)
 - [Examples](#examples)
 - [Documentation](#documentation)
@@ -55,9 +58,12 @@ probability, repeat count, and time-to-solution estimates.
 Repeat reliability follows Noori et al. 2026:
 
 Noori, Moslem, Elisabetta Valiante, Ignacio Rozada, Thomas Van Vaerenbergh, and
-Masoud Mohseni. "Statistical analysis for per-instance evaluation of stochastic
-optimizers: Avoiding unreliable conclusions." Physical Review Applied 25, no. 3
-(2026): 034081.
+Masoud Mohseni. "[Statistical analysis for per-instance evaluation of stochastic
+optimizers: Avoiding unreliable conclusions](https://doi.org/10.1103/PhysRevApplied.25.034081)."
+Physical Review Applied 25, no. 3 (2026): 034081. The related
+[arXiv preprint](https://arxiv.org/abs/2503.16589) is titled "A Statistical
+Analysis for Per-Instance Evaluation of Stochastic Optimizers: How Many Repeats
+Are Enough?"
 
 The analytic guarantees implemented here apply to Bernoulli success events and
 metrics derived from their success probabilities: `R_c`, RTT/TTS, CETS, and
@@ -85,6 +91,12 @@ Use [docs/passive_repeat_reliability_reports.md](docs/passive_repeat_reliability
 to add passive repeat-reliability reports to existing benchmark data. Use
 [docs/noori_repeat_reliability_validation.md](docs/noori_repeat_reliability_validation.md)
 for the equation map and validation boundaries.
+
+## References
+
+- Window Sticker methodology: [published Quantum Machine Intelligence article](https://link.springer.com/article/10.1007/s42484-025-00311-2) and [arXiv preprint](https://arxiv.org/abs/2402.10255).
+- Repeat reliability: [published Physical Review Applied article](https://doi.org/10.1103/PhysRevApplied.25.034081) and [arXiv preprint](https://arxiv.org/abs/2503.16589).
+- QAOA benchmark case: [published ACM Transactions on Quantum Computing article](https://doi.org/10.1145/3678184) and [arXiv preprint](https://arxiv.org/abs/2302.02278).
 
 ## Installation
 

--- a/docs/noori_repeat_reliability_validation.md
+++ b/docs/noori_repeat_reliability_validation.md
@@ -13,9 +13,12 @@ helpers retain `confidence_fraction` for equation-oriented tests. In both cases,
 Paper reference:
 
 Noori, Moslem, Elisabetta Valiante, Ignacio Rozada, Thomas Van Vaerenbergh, and
-Masoud Mohseni. "Statistical analysis for per-instance evaluation of stochastic
-optimizers: Avoiding unreliable conclusions." Physical Review Applied 25, no. 3
-(2026): 034081.
+Masoud Mohseni. "[Statistical analysis for per-instance evaluation of stochastic
+optimizers: Avoiding unreliable conclusions](https://doi.org/10.1103/PhysRevApplied.25.034081)."
+Physical Review Applied 25, no. 3 (2026): 034081. The related
+[arXiv preprint](https://arxiv.org/abs/2503.16589) is titled "A Statistical
+Analysis for Per-Instance Evaluation of Stochastic Optimizers: How Many Repeats
+Are Enough?"
 
 ## Equation Map
 

--- a/examples/general_workflow.md
+++ b/examples/general_workflow.md
@@ -8,7 +8,8 @@ Given a benchmark task, the workflow generally follows these steps:
 4. Train/Test split and Statistical Aggregation
 5. Virtual Best Baseline
 6. Evaluating Parameter Recommendation Strategies
-7. Visualization
+7. Repeat Reliability
+8. Visualization
 
 Each step is explored in greater detail along with code implementation at `examples/QAOA_iterative/qaoa_demo.ipynb`.
 ## Define the Metrics
@@ -41,6 +42,53 @@ After having devised parameter recommendations from the training set, we need a 
 
 1. We can aggregate statistics across all training instances to learn a parameter recipe. We refer to this as the Aggregate-then-Recommend projection strategy.
 2. It is also possible to look at what parameters work best for each instance individually. After this, we can average those recommendations.
+
+## Repeat Reliability
+
+Noori et al. 2026 show that per-instance stochastic optimizer conclusions can
+be unreliable when they are based on too few repeats:
+
+Noori, Moslem, Elisabetta Valiante, Ignacio Rozada, Thomas Van Vaerenbergh, and
+Masoud Mohseni. "Statistical analysis for per-instance evaluation of stochastic
+optimizers: Avoiding unreliable conclusions." Physical Review Applied 25, no. 3
+(2026): 034081.
+
+This check is separate from the cross-instance Window Sticker uncertainty used
+elsewhere in the workflow. Window Sticker plots summarize expected performance
+over unseen instances from a problem family. Repeat reliability checks whether a
+specific instance, solver configuration, and resource level has enough repeated
+runs to estimate its success probability and the derived repeat counts.
+
+Analytic repeat-reliability guarantees apply when each run can be treated as a
+Bernoulli success event. In this package that covers:
+
+- `R_c`, the repeats required to reach a target success confidence
+- RTT/TTS values derived from `R_c` and runtime-per-repeat scaling
+- CETS values derived from `R_c`, iterations, and effort-per-iteration scaling
+- Thresholded continuous metrics, such as Response or PerfRatio after a
+  success threshold converts each run into success or failure
+
+Continuous Response curves and continuous PerfRatio curves remain
+bootstrap-based unless they are converted to thresholded success events. Their
+bootstrap intervals describe empirical cross-instance variation and resampling
+uncertainty, not the analytic repeat-count guarantees from the paper.
+
+Use `repeat_reliability_report` or `stochastic_benchmark.run_RepeatReliability`
+before treating a benchmark conclusion as final. The resulting
+`required_trials`, `additional_trials_required`, `reliable`, and
+`reliability_status` columns tell users whether the existing data are reliable
+enough or whether the solver should be rerun.
+
+## Methodology Criticism Checklist
+
+| Criticism | Workflow response |
+| --- | --- |
+| Repeat-count sufficiency | Check required and additional trials before trusting a per-instance success estimate. |
+| Bootstrap-only uncertainty | Use analytic Bernoulli intervals for success events and keep bootstrap intervals for continuous cross-instance curves. |
+| Noisy HPO choices | Treat parameter recommendations as provisional when repeat reliability is low or intervals are wide. |
+| CI-overlap ambiguity | Mark overlapping comparisons as statistically unresolved instead of selecting a winner from point estimates alone. |
+| Virtual-best optimism | Interpret virtual best as an unattainable optimistic reference, not as a deployable strategy. |
+
 ## Visualization
 
 The framework's results can be visualized, mainly, through two lenses:

--- a/examples/general_workflow.md
+++ b/examples/general_workflow.md
@@ -11,7 +11,12 @@ Given a benchmark task, the workflow generally follows these steps:
 7. Repeat Reliability
 8. Visualization
 
-Each step is explored in greater detail along with code implementation at `examples/QAOA_iterative/qaoa_demo.ipynb`.
+Each step is explored in greater detail along with code implementation at
+`examples/QAOA_iterative/qaoa_demo.ipynb`. For the QAOA benchmark context, see
+the published ACM Transactions on Quantum Computing article
+[*Optimization Applications as Quantum Performance Benchmarks*](https://doi.org/10.1145/3678184)
+and its [arXiv preprint](https://arxiv.org/abs/2302.02278).
+
 ## Define the Metrics
 In this first step, we configure the central object for the benchmark task. We define:
 
@@ -49,9 +54,12 @@ Noori et al. 2026 show that per-instance stochastic optimizer conclusions can
 be unreliable when they are based on too few repeats:
 
 Noori, Moslem, Elisabetta Valiante, Ignacio Rozada, Thomas Van Vaerenbergh, and
-Masoud Mohseni. "Statistical analysis for per-instance evaluation of stochastic
-optimizers: Avoiding unreliable conclusions." Physical Review Applied 25, no. 3
-(2026): 034081.
+Masoud Mohseni. "[Statistical analysis for per-instance evaluation of stochastic
+optimizers: Avoiding unreliable conclusions](https://doi.org/10.1103/PhysRevApplied.25.034081)."
+Physical Review Applied 25, no. 3 (2026): 034081. The related
+[arXiv preprint](https://arxiv.org/abs/2503.16589) is titled "A Statistical
+Analysis for Per-Instance Evaluation of Stochastic Optimizers: How Many Repeats
+Are Enough?"
 
 This check is separate from the cross-instance Window Sticker uncertainty used
 elsewhere in the workflow. Window Sticker plots summarize expected performance

--- a/tests/test_methodology_docs.py
+++ b/tests/test_methodology_docs.py
@@ -1,0 +1,44 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def read_doc(relative_path):
+    return (ROOT / relative_path).read_text(encoding="utf-8")
+
+
+def test_readme_documents_repeat_reliability_boundaries():
+    readme = " ".join(read_doc("README.md").split())
+
+    for required in [
+        "Noori, Moslem",
+        "Physical Review Applied 25",
+        "cross-instance Window Sticker uncertainty",
+        "Per-instance repeat-count reliability",
+        "Bernoulli success events",
+        "`R_c`",
+        "RTT/TTS",
+        "CETS",
+        "thresholded continuous metrics",
+        "continuous Response curves",
+        "continuous PerfRatio curves",
+    ]:
+        assert required in readme
+
+
+def test_general_workflow_maps_repeat_reliability_criticisms():
+    workflow = " ".join(read_doc("examples/general_workflow.md").split())
+
+    for criticism in [
+        "Repeat-count sufficiency",
+        "Bootstrap-only uncertainty",
+        "Noisy HPO choices",
+        "CI-overlap ambiguity",
+        "Virtual-best optimism",
+    ]:
+        assert criticism in workflow
+
+    assert "cross-instance Window Sticker uncertainty" in workflow
+    assert "Bernoulli success event" in workflow
+    assert "Continuous Response curves and continuous PerfRatio curves" in workflow

--- a/tests/test_methodology_docs.py
+++ b/tests/test_methodology_docs.py
@@ -23,6 +23,12 @@ def test_readme_documents_repeat_reliability_boundaries():
         "thresholded continuous metrics",
         "continuous Response curves",
         "continuous PerfRatio curves",
+        "https://link.springer.com/article/10.1007/s42484-025-00311-2",
+        "https://arxiv.org/abs/2402.10255",
+        "https://doi.org/10.1103/PhysRevApplied.25.034081",
+        "https://arxiv.org/abs/2503.16589",
+        "https://doi.org/10.1145/3678184",
+        "https://arxiv.org/abs/2302.02278",
     ]:
         assert required in readme
 
@@ -42,3 +48,12 @@ def test_general_workflow_maps_repeat_reliability_criticisms():
     assert "cross-instance Window Sticker uncertainty" in workflow
     assert "Bernoulli success event" in workflow
     assert "Continuous Response curves and continuous PerfRatio curves" in workflow
+    assert "https://doi.org/10.1145/3678184" in workflow
+    assert "https://arxiv.org/abs/2302.02278" in workflow
+
+
+def test_noori_validation_doc_links_published_and_arxiv_versions():
+    validation_doc = read_doc("docs/noori_repeat_reliability_validation.md")
+
+    assert "https://doi.org/10.1103/PhysRevApplied.25.034081" in validation_doc
+    assert "https://arxiv.org/abs/2503.16589" in validation_doc


### PR DESCRIPTION
## Summary

- Document how repeat reliability changes Window Sticker methodology claims.
- Separate cross-instance bootstrap uncertainty from per-instance repeat-count reliability.
- Clarify that Noori et al. 2026 analytic guarantees apply to Bernoulli success events, `R_c`, RTT/TTS, CETS, and thresholded continuous metrics, while continuous Response and PerfRatio curves remain bootstrap-based unless thresholded.
- Add a methodology criticism mapping and documentation regression tests.

## Tests run

- `python -m pytest tests/test_methodology_docs.py -q` - 2 passed.
- `python run_tests.py unit --fast` - 413 passed, 12 warnings.
- `flake8 src --count --select=E9,F63,F7,F82 --show-source --statistics` - 0 critical issues.
- `flake8 src --count --exit-zero --max-complexity=10 --max-line-length=120 --statistics` - exited 0; printed existing advisory style warnings.
- `python run_tests.py integration` - 11 passed.

## Notes about tests not run

- Did not run local tutorial notebook execution or local coverage report generation; CI covers those heavier checks.
- No separate type-check or formatting command is documented for this repository.

Closes #76
