### PR TITLE
Remove vulnerable Setuptools pin from generation dependencies

### DIFF
--- a/.github/copilot-setup-steps.yml
+++ b/.github/copilot-setup-steps.yml
@@ -28,8 +28,7 @@ setup_steps:
         - nbconvert
         - ipykernel
       generation:
-        - hyperopt
-        - "setuptools<81"
+        - "hyperopt>=0.3.0"
       development:
         - flake8
         - black  # code formatter

--- a/CI-TESTING.md
+++ b/CI-TESTING.md
@@ -177,8 +177,7 @@ The CI environment includes:
 - ipykernel >= 6
 
 **Optional Data-Generation Dependencies:**
-- hyperopt >= 0.2.7
-- setuptools < 81 (temporary Hyperopt 0.2.7 compatibility workaround)
+- hyperopt >= 0.3.0
 
 **Testing Tools:**
 - pytest

--- a/README.md
+++ b/README.md
@@ -115,7 +115,8 @@ pip install -e ".[examples,notebooks]"
 pip install -e ".[generation]"
 ```
 
-The generation requirements include a temporary `setuptools<81` compatibility pin because Hyperopt 0.2.7 imports `pkg_resources`. This workaround is generation-specific and is not needed for analysis-only notebooks.
+The generation requirements use Hyperopt 0.3.0 or newer, which supports current
+Python packaging tools without the removed `pkg_resources` API.
 
 <!-- the following `pip` command can install this package -->
 

--- a/examples/wishart_n_50_alpha_0.5/README.md
+++ b/examples/wishart_n_50_alpha_0.5/README.md
@@ -29,7 +29,8 @@ Install the generation dependencies from this directory with:
 pip install -r ../../requirements-generation.txt
 ```
 
-`requirements-generation.txt` includes a temporary `setuptools<81` compatibility pin for Hyperopt 0.2.7, which imports `pkg_resources`. This pin is only for generation workflows and is not required to run analysis notebooks.
+`requirements-generation.txt` uses Hyperopt 0.3.0 or newer, which supports
+current Python packaging tools without the removed `pkg_resources` API.
 
 These generation-only dependencies are imported lazily by `wishart_runs.py`, so importing the analysis helpers in `wishart_ws.py` does not require them.
 

--- a/examples/wishart_n_50_alpha_0.5/wishart_n_50_alpha_0.50.ipynb
+++ b/examples/wishart_n_50_alpha_0.5/wishart_n_50_alpha_0.50.ipynb
@@ -69,9 +69,6 @@
     "# Configure warning filters\n",
     "import warnings\n",
     "\n",
-    "# Suppress known harmless warnings\n",
-    "warnings.filterwarnings('ignore', message='pkg_resources is deprecated')\n",
-    "\n",
     "# Show sequential search data warning only once\n",
     "# This is expected when sequential search encounters sparse data regions\n",
     "warnings.filterwarnings('once', message='Sequential search experiment terminated due to insufficient data')"

--- a/examples/wishart_n_50_alpha_0.5/wishart_ws.py
+++ b/examples/wishart_n_50_alpha_0.5/wishart_ws.py
@@ -8,11 +8,7 @@ import os
 import pandas as pd
 import sys
 from tqdm import tqdm
-import warnings
 from wishart_paths import logname
-
-# Filter known third-party warnings
-warnings.filterwarnings('ignore', message='pkg_resources is deprecated')
 
 sys.path.append('../../src') #TODO set path to point to src of stochastic-benchmark
 import bootstrap

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-    "setuptools>=42",
+    "setuptools>=83",
     "wheel"
 ]
 build-backend = "setuptools.build_meta"

--- a/requirements-generation.txt
+++ b/requirements-generation.txt
@@ -1,8 +1,3 @@
 # Optional dependencies for data-generation workflows
 # These are NOT required for core stochastic-benchmark analysis or examples
-hyperopt>=0.2.7
-
-# Temporary Hyperopt compatibility workaround:
-# Hyperopt 0.2.7 imports pkg_resources, which is not available in setuptools 81+.
-# Keep this generation-specific until Hyperopt no longer needs pkg_resources.
-setuptools<81
+hyperopt>=0.3.0

--- a/setup.py
+++ b/setup.py
@@ -29,8 +29,7 @@ EXTRAS_REQUIRE = {
         "ipykernel>=6",
     ],
     "generation": [
-        "hyperopt>=0.2.7",
-        "setuptools<81",
+        "hyperopt>=0.3.0",
     ],
 }
 

--- a/tests/test_optional_dependencies.py
+++ b/tests/test_optional_dependencies.py
@@ -57,22 +57,26 @@ def test_example_requirements_cover_self_contained_notebook_dependencies():
 def test_generation_requirements_are_separate_from_core():
     generation_requirements = _requirements(REPO_ROOT / "requirements-generation.txt")
 
-    assert "hyperopt" in _requirement_names(generation_requirements)
-    assert any(requirement == "setuptools<81" for requirement in generation_requirements)
+    assert "hyperopt>=0.3.0" in generation_requirements
+    assert "setuptools" not in _requirement_names(generation_requirements)
 
 
 def test_setup_extras_match_optional_dependency_groups():
     install_requires = _setup_constant("INSTALL_REQUIRES")
     extras_require = _setup_constant("EXTRAS_REQUIRE")
 
-    assert "hyperopt>=0.2.7" not in install_requires
+    assert "hyperopt>=0.3.0" not in install_requires
     assert {"scikit-learn>=1.3.0", "dimod>=0.12"} <= set(
         extras_require["examples"]
     )
     assert {"nbconvert>=7", "ipykernel>=6"} <= set(extras_require["notebooks"])
-    assert {"hyperopt>=0.2.7", "setuptools<81"} <= set(
-        extras_require["generation"]
-    )
+    assert extras_require["generation"] == ["hyperopt>=0.3.0"]
+
+
+def test_build_backend_requires_patched_setuptools():
+    pyproject = (REPO_ROOT / "pyproject.toml").read_text()
+
+    assert '"setuptools>=83"' in pyproject
 
 
 def test_wishart_generation_reports_clear_error_without_hyperopt(monkeypatch):


### PR DESCRIPTION
## Summary

- require Hyperopt 0.3.0, which replaced its `pkg_resources` usage with `importlib.resources`
- remove Setuptools from the runtime/generation dependency surface
- require patched Setuptools 83+ only in the isolated build backend
- remove obsolete warning suppression and document/test the supported dependency policy

This resolves [Dependabot alert 4](https://github.com/usra-riacs/stochastic-benchmark/security/dependabot/4). Dependabot could not generate a compatible update because the old Hyperopt workaround required `setuptools<81`, while the alert is only patched in Setuptools 83.0.0+.

## Verification

- `python run_tests.py unit` — 402 passed
- isolated `python -m build --sdist` with `setuptools>=83`
- Hyperopt 0.3.0 API smoke test using the Wishart workflow imports, with `pkg_resources` deliberately unavailable
- notebook JSON validation and `git diff --check`